### PR TITLE
Redfish mockup server print flush

### DIFF
--- a/redfishMockupServer/AUTHORS.md
+++ b/redfishMockupServer/AUTHORS.md
@@ -1,0 +1,7 @@
+
+# Original Contribution:
+* Paul Vancil - Dell Inc. -- Dell Extreme Scale Infrastructure (ESI) Architecture Team
+
+
+# Other Key Contributions:
+

--- a/redfishMockupServer/CHANGELOG.md
+++ b/redfishMockupServer/CHANGELOG.md
@@ -1,0 +1,6 @@
+
+# Change Log
+
+## [0.9.1] - 2016-09-06
+- Initial Public Release
+- 

--- a/redfishMockupServer/LICENSE.md
+++ b/redfishMockupServer/LICENSE.md
@@ -1,0 +1,57 @@
+The Distributed Management Task Force (DMTF) grants rights under copyright in
+this software on the terms of the BSD 3-Clause License as set forth below; no
+other rights are granted by DMTF. This software might be subject to other rights
+(such as patent rights) of other parties.
+
+
+### Copyrights.
+
+Copyright (c) 2016, Contributing Member(s) of Distributed Management Task Force,
+Inc.. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+* Neither the name of the Distributed Management Task Force (DMTF) nor the names
+of its contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+### Patents.
+
+This software may be subject to third party patent rights, including provisional
+patent rights ("patent rights"). DMTF makes no representations to users of the
+standard as to the existence of such rights, and is not responsible to
+recognize, disclose, or identify any or all such third party patent right,
+owners or claimants, nor for any incomplete or inaccurate identification or
+disclosure of such rights, owners or claimants. DMTF shall have no liability to
+any party, in any manner or circumstance, under any legal theory whatsoever, for
+failure to recognize, disclose, or identify any such third party patent rights,
+or for such party's reliance on the software or incorporation thereof in its
+product, protocols or testing procedures. DMTF shall have no liability to any
+party using such software, whether such use is foreseeable or not, nor to any
+patent owner or claimant, and shall have no liability or responsibility for
+costs or losses incurred if software is withdrawn or modified after publication,
+and shall be indemnified and held harmless by any party using the software from
+any and all claims of infringement by a patent owner for such use.
+
+DMTF Members that contributed to this software source code might have made
+patent licensing commitments in connection with their participation in the DMTF.
+For details, see http://dmtf.org/sites/default/files/patent-10-18-01.pdf and
+http://www.dmtf.org/about/policies/disclosures.

--- a/redfishMockupServer/README.md
+++ b/redfishMockupServer/README.md
@@ -1,0 +1,31 @@
+Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+
+# redfishMockupServer
+
+## About
+***redfishMockupServer*** is a short python 3.4+ program that can be copied into folder at top of any redfish mockup and can serve redfish requests on the specified IP/port.
+
+## Usage
+###To start the server:
+* copy to the folder that is the top of the mockup.  
+ * "redfish" should be a sub-directory.   
+ * This is a "Tall Mockup" which includes /redfish/v1 in the mockup directory structure in case some of the URIs in the mockup do not start with /redfish/v1.
+
+* make sure python34 is in your path
+* run redfishMockupServer from your windows command shell: `.\redfishMockupServer`
+* Default hostname/IP is localhost:  127.0.0.1
+* Default port is:  8000
+* You can create multiple mockup servers running on multiple ports:
+
+### Options:
+
+* `redfishMockupServer -h`     -- gives help usage and exits
+
+* `redfishMockupServer [-H *HostIpAddress* ] [-P *port*]`    
+  * default *HostIpAddress* is 127.0.0.1
+  * default *port*         is 8000
+* Example:    
+`.\redfishMockupServer -P 8001`   # to start another service on port 8001
+
+
+

--- a/redfishMockupServer/redfishMockupServer.py
+++ b/redfishMockupServer/redfishMockupServer.py
@@ -1,0 +1,179 @@
+# Copyright Notice:
+# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tools/LICENSE.md
+
+# redfishMockupServer.py
+# v0.9.1
+# tested and developed Python 3.4
+
+import urllib
+import cgi
+import sys
+import getopt
+
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class RfMockupServer(BaseHTTPRequestHandler):
+        '''
+        returns index.json file for Serverthe specified URL
+        '''
+        server_version = "RedfishMockupHTTPD_v0.9.1"
+
+        def do_GET(self):
+                # for GETs always dump the request headers to the console
+                # there is no request data, so no need to dump that
+                print("   GET: Headers: {}".format(self.headers))
+                rfile="index.json"
+                rfileXml="index.xml"
+                f=None
+
+                #xpath = self.translate_path(self.path)
+
+                if(self.path[0]=='/'):
+                        rpath=self.path[1:]
+                rpath = rpath.split('?',1)[0]
+                rpath = rpath.split('#',1)[0]
+                apath=os.path.abspath(rpath)
+                fpath=os.path.join(apath,rfile)
+                fpathxml=os.path.join(apath,rfileXml)
+                #print("filepath:{}".format(fpath))
+
+                if( os.path.isfile(fpath) is True):
+                        self.send_response(200)
+                        self.send_header("Content-type", "application/json")
+                        # special cases to test etag for testing
+                        # if etag is returned then the patch to these resource should include this etag
+                        if( self.path=="/redfish/v1/Systems/1" ):
+                                self.send_header("Etag", "W/\"12345\"")
+                        elif( self.path=="/redfish/v1/AccountService/Accounts/1" ):
+                                self.send_header("Etag", "W/\"123456\"")
+                        self.end_headers()
+                        f=open(fpath,"r")
+                        self.wfile.write(f.read().encode())
+                        f.close()
+                elif( os.path.isfile(fpathxml) is True):
+                        self.send_response(200)
+                        self.send_header("Content-type", "application/xml")
+                        self.end_headers()
+                        f=open(fpathxml,"r")
+                        self.wfile.write(f.read().encode())
+                        f.close()
+                else:
+                        self.send_response(404)
+                        self.end_headers()
+                        
+        def do_PATCH(self):
+                print("   PATCH: Headers: {}".format(self.headers))
+                if( "content-length" in self.headers ):
+                        len=int(self.headers["content-length"])
+                        dataa=self.rfile.read(len)
+                        print("   PATCH: Data: {}".format(dataa))
+                self.send_response(204)
+                self.end_headers()
+                
+        def do_POST(self):
+                print("   POST: Headers: {}".format(self.headers))
+                if( "content-length" in self.headers ):
+                        len=int(self.headers["content-length"])
+                        dataa=self.rfile.read(len)
+                        print("   POST: Data: {}".format(dataa))
+                self.send_response(204)
+                self.end_headers()
+                
+        def do_DELETE(self):
+                print("DELETE: Headers: {}".format(self.headers))
+                if( "content-length" in self.headers ):
+                        # Deletes don't have data, so this doesnt execute
+                        len=int(self.headers["content-length"])
+                        dataa=self.rfile.read(len)
+                        print("DELETE: Data: {}".format(dataa))
+                self.send_response(204)
+                self.end_headers()
+                
+        # this is currently not used
+        def translate_path(self, path):
+                """
+                Translate a /-separated PATH to the local filename syntax.
+                Components that mean special things to the local file system
+                (e.g. drive or directory names) are ignored.  (XXX They should
+                probably be diagnosed.)
+                """
+                # abandon query parameters
+                path = path.split('?',1)[0]
+                path = path.split('#',1)[0]
+                path = posixpath.normpath(urllib.unquote(path))
+                words = path.split('/')
+                words = filter(None, words)
+                path = os.getcwd()
+                for word in words:
+                        drive, word = os.path.splitdrive(word)
+                        head, word = os.path.split(word)
+                        if word in (os.curdir, os.pardir): continue
+                path = os.path.join(path, word)
+                return path
+
+def usage(program):
+        print("usage: {}   [-h][-P][-H <hostIpAddr>:<port>]".format(program))
+        print("      -h --help      # prints usage ")
+        print("      -L --Load      # <not implemented yet>: load and Dump json read from mockup in pretty format with indent=4")
+        print("      -H <IpAddr>   --Host=<IpAddr>    # hostIP, default: 127.0.0.1")
+        print("      -P <port>     --Port=<port>      # port:  default is 8000")
+        print("   by default, service runs on 127.0.0.1:8000, using raw JSON response from mockup")
+
+def main(argv):
+        hostname="127.0.0.1"
+        port=8000
+        load=False
+        program=argv[0]
+        print(program)
+        
+        try:
+                opts, args = getopt.getopt(argv[1:],"hLH:P:",["help","Load","Host=","Port="])
+        except getopt.GetoptError as err:
+                #usage()
+                print(err)
+                usage()
+                sys.exit(2)
+
+        for opt, arg in opts:
+                if opt in ("-h", "--help"):
+                        usage(program)
+                        sys.exit(0)
+                elif opt in ("L", "--Load"):
+                        load=True
+                elif opt in ("-H", "--Host"):
+                        hostname=arg
+                elif opt in ("-P", "--Port"):
+                        port=int(arg)
+                else:
+                        print('unhandled option')
+                        sys.exit(2)
+
+        print ('program: ', program)
+        print ('Hostname:', hostname)
+        print ('Port:', port)
+
+        myServer=HTTPServer((hostname, port), RfMockupServer)
+        print( 'Serving Redfish mockup on port:', port)
+        try:
+                myServer.serve_forever()
+        except KeyboardInterupt:
+                pass
+
+        myServer.server_close()
+        print("Shutting down http server")
+        
+
+# the below is only executed if the program is run as a script
+if __name__ == "__main__":
+        main(sys.argv)
+
+'''
+TODO:
+1. add -L option to load json and dump output from python dictionary
+2. add authentication support -- note that in redfish some api don't require auth
+3. add https support
+
+
+'''

--- a/redfishMockupServer/redfishMockupServer.py
+++ b/redfishMockupServer/redfishMockupServer.py
@@ -130,10 +130,10 @@ def main(argv):
         
         try:
                 opts, args = getopt.getopt(argv[1:],"hLH:P:",["help","Load","Host=","Port="])
-        except getopt.GetoptError as err:
+        except getopt.GetoptError:
                 #usage()
-                print(err)
-                usage()
+                print("Error parsing options")
+                usage(program)
                 sys.exit(2)
 
         for opt, arg in opts:
@@ -153,9 +153,11 @@ def main(argv):
         print ('program: ', program)
         print ('Hostname:', hostname)
         print ('Port:', port)
+        sys.stdout.flush()
 
         myServer=HTTPServer((hostname, port), RfMockupServer)
         print( 'Serving Redfish mockup on port:', port)
+        sys.stdout.flush()
         try:
                 myServer.serve_forever()
         except KeyboardInterupt:
@@ -163,6 +165,7 @@ def main(argv):
 
         myServer.server_close()
         print("Shutting down http server")
+        sys.stdout.flush()
         
 
 # the below is only executed if the program is run as a script


### PR DESCRIPTION
if you start mockup server from a cygwin, the early print statements re port, IP don't show due to print output being buffered and never pushed out before the http server starts.
Added flush before starting the httpd