### PR TITLE
Redfish mockup server0.9.2

### DIFF
--- a/redfishMockupServer/CHANGELOG.md
+++ b/redfishMockupServer/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change Log
 
+## [0.9.2] - 2016-09-07
+- added flush to server prints so that buffered stdout on cygwin would work
+- added -T option to enable returning fake etags on certain APIs -instead of always doing it
+- added -D <dir>  option  where <dir> is the abs or relative path to the mockup.  if no -D option, then CWD is assumed
+
 ## [0.9.1] - 2016-09-06
 - Initial Public Release
 - 

--- a/redfishMockupServer/README.md
+++ b/redfishMockupServer/README.md
@@ -7,12 +7,14 @@ Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
 
 ## Usage
 ###To start the server:
-* copy to the folder that is the top of the mockup.  
+* copy the ***redfishMockupServer.py*** file to the the folder you want to execute it from
+* use the `-D <mockupDir>` option to specify an absolute or relative path to the mockup dir from CWD
+* Note that the mockup directory must start with /redfish:  
  * "redfish" should be a sub-directory.   
  * This is a "Tall Mockup" which includes /redfish/v1 in the mockup directory structure in case some of the URIs in the mockup do not start with /redfish/v1.
 
 * make sure python34 is in your path
-* run redfishMockupServer from your windows command shell: `.\redfishMockupServer`
+* run redfishMockupServer from your windows command shell eg: `.\redfishMockupServer [-D <mockupDir>]`
 * Default hostname/IP is localhost:  127.0.0.1
 * Default port is:  8000
 * You can create multiple mockup servers running on multiple ports:
@@ -21,9 +23,12 @@ Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
 
 * `redfishMockupServer -h`     -- gives help usage and exits
 
-* `redfishMockupServer [-H *HostIpAddress* ] [-P *port*]`    
+* `redfishMockupServer [-H *HostIpAddress* ] [-P *port*] [-D <mockupDir>] [-H <host>] [-P <port>] [-T]`    
   * default *HostIpAddress* is 127.0.0.1
   * default *port*         is 8000
+  * *mockupDir* is absolute or relative to CWD if starting with . or ..
+  * -T option causes mockup server to generate etags on GETs for certain hard coded APIs for testing client patch etag code
+    * 
 * Example:    
 `.\redfishMockupServer -P 8001`   # to start another service on port 8001
 

--- a/redfishMockupServer/README.md
+++ b/redfishMockupServer/README.md
@@ -28,9 +28,10 @@ Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
   * default *port*         is 8000
   * *mockupDir* is absolute or relative to CWD if starting with . or ..
   * -T option causes mockup server to generate etags on GETs for certain hard coded APIs for testing client patch etag code
-    * 
+    * response header Etag: "W/12345" is returned on GET /redfish/v1/Systems/1
+    * response header Etag: "123456"  is returned on GET /redfish/v1/AccountService/Accounts/1
 * Example:    
-`.\redfishMockupServer -P 8001`   # to start another service on port 8001
+`.\redfishMockupServer -P 8001 -D ./MyServerMockup9`   # to start another service on port 8001 from folder *./MyServerMockup9*
 
 
 

--- a/redfishMockupServer/redfishMockupServer.py
+++ b/redfishMockupServer/redfishMockupServer.py
@@ -132,7 +132,6 @@ def usage(program):
         print("      -H <IpAddr>   --Host=<IpAddr>    # hostIP, default: 127.0.0.1")
         print("      -P <port>     --Port=<port>      # port:  default is 8000")
         print("      -D <dir>,     --Dir=<dir>        # the to the mockup directory. It may be relative to CWD")
-        print("      -D <dir>,     --Dir=<dir>        # the to the mockup directory. It may be relative to CWD")
         print("      -T --TestEtag  # etag testing--enable returning etag for certain APIs for testing.  See Readme")
         sys.stdout.flush()
 

--- a/redfishMockupServer/redfishMockupServer.py
+++ b/redfishMockupServer/redfishMockupServer.py
@@ -3,7 +3,7 @@
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tools/LICENSE.md
 
 # redfishMockupServer.py
-# v0.9.1
+# v0.9.2
 # tested and developed Python 3.4
 
 import urllib
@@ -18,12 +18,14 @@ class RfMockupServer(BaseHTTPRequestHandler):
         '''
         returns index.json file for Serverthe specified URL
         '''
-        server_version = "RedfishMockupHTTPD_v0.9.1"
+        server_version = "RedfishMockupHTTPD_v0.9.2"
 
         def do_GET(self):
                 # for GETs always dump the request headers to the console
                 # there is no request data, so no need to dump that
                 print("   GET: Headers: {}".format(self.headers))
+                sys.stdout.flush()
+
                 rfile="index.json"
                 rfileXml="index.xml"
                 f=None
@@ -34,20 +36,30 @@ class RfMockupServer(BaseHTTPRequestHandler):
                         rpath=self.path[1:]
                 rpath = rpath.split('?',1)[0]
                 rpath = rpath.split('#',1)[0]
-                apath=os.path.abspath(rpath)
-                fpath=os.path.join(apath,rfile)
+                
+                # get the testEtagFlag and mockup directory path parameters passed in from the http server
+                apath=self.server.mockDir    # this is the real absolute path to the mockup directory
+                testEtagFlag=self.server.testEtagFlag
+                #print("-------apath; {}".format(apath))
+                #print("-------test: {}".format(testEtagFlag))
+
+                # form the path in the mockup of the file
+                #      old only support mockup in CWD:  apath=os.path.abspath(rpath)
+                fpath=os.path.join(apath,rpath, rfile)
                 fpathxml=os.path.join(apath,rfileXml)
-                #print("filepath:{}".format(fpath))
+                #print("-------filepath:{}".format(fpath))
+                sys.stdout.flush()
 
                 if( os.path.isfile(fpath) is True):
                         self.send_response(200)
                         self.send_header("Content-type", "application/json")
                         # special cases to test etag for testing
-                        # if etag is returned then the patch to these resource should include this etag
-                        if( self.path=="/redfish/v1/Systems/1" ):
-                                self.send_header("Etag", "W/\"12345\"")
-                        elif( self.path=="/redfish/v1/AccountService/Accounts/1" ):
-                                self.send_header("Etag", "W/\"123456\"")
+                        # if etag is returned then the patch to these resources should include this etag
+                        if( testEtagFlag is True ):
+                                if( self.path=="/redfish/v1/Systems/1" ):
+                                        self.send_header("Etag", "W/\"12345\"")
+                                elif( self.path=="/redfish/v1/AccountService/Accounts/1" ):
+                                        self.send_header("Etag", "\"123456\"")
                         self.end_headers()
                         f=open(fpath,"r")
                         self.wfile.write(f.read().encode())
@@ -119,7 +131,11 @@ def usage(program):
         print("      -L --Load      # <not implemented yet>: load and Dump json read from mockup in pretty format with indent=4")
         print("      -H <IpAddr>   --Host=<IpAddr>    # hostIP, default: 127.0.0.1")
         print("      -P <port>     --Port=<port>      # port:  default is 8000")
-        print("   by default, service runs on 127.0.0.1:8000, using raw JSON response from mockup")
+        print("      -D <dir>,     --Dir=<dir>        # the to the mockup directory. It may be relative to CWD")
+        print("      -D <dir>,     --Dir=<dir>        # the to the mockup directory. It may be relative to CWD")
+        print("      -T --TestEtag  # etag testing--enable returning etag for certain APIs for testing.  See Readme")
+        sys.stdout.flush()
+
 
 def main(argv):
         hostname="127.0.0.1"
@@ -127,12 +143,16 @@ def main(argv):
         load=False
         program=argv[0]
         print(program)
+        mockDirPath=None
+        mockDir=None
+        testEtagFlag=False
         
         try:
-                opts, args = getopt.getopt(argv[1:],"hLH:P:",["help","Load","Host=","Port="])
+                opts, args = getopt.getopt(argv[1:],"hLTH:P:D:",["help","Load", "TestEtag", "Host=", "Port=", "Dir="])
         except getopt.GetoptError:
                 #usage()
-                print("Error parsing options")
+                print("Error parsing options", file=sys.stderr)
+                sys.stderr.flush()
                 usage(program)
                 sys.exit(2)
 
@@ -146,17 +166,44 @@ def main(argv):
                         hostname=arg
                 elif opt in ("-P", "--Port"):
                         port=int(arg)
+                elif opt in ("-D", "--Dir"):
+                        mockDirPath=arg
+                elif opt in ("-T", "--TestEtag"):
+                        testEtagFlag=True
                 else:
-                        print('unhandled option')
+                        print('unhandled option', file=sys.stderr)
                         sys.exit(2)
 
         print ('program: ', program)
         print ('Hostname:', hostname)
         print ('Port:', port)
+        print ("dir path specified by user:{}".format(mockDirPath))
         sys.stdout.flush()
 
+        # check if mockup path was specified.  If not, use current working directory
+        if mockDirPath is None:
+                mockDirPath=os.getcwd()
+
+        #create the full path to the top directory holding the Mockup  
+        mockDir=os.path.realpath(mockDirPath) #creates real full path including path for CWD to the -D<mockDir> dir path
+        
+        print ("Serving Mockup in abs real directory path:{}".format(mockDir))
+
+        # check that we have a valid tall mockup--with /redfish in mockDir before proceeding
+        slashRedfishDir=os.path.join(mockDir, "redfish")
+        if os.path.isdir(slashRedfishDir) is not True:
+                print("ERROR: Invalid Mockup Directory--no /redfish directory at top. Aborting", file=sys.stderr)
+                sys.stderr.flush()
+                sys.exit(1)
+
         myServer=HTTPServer((hostname, port), RfMockupServer)
-        print( 'Serving Redfish mockup on port:', port)
+
+        # save the test flag, and real path to the mockup dir for the handler to use
+        myServer.mockDir=mockDir
+        myServer.testEtagFlag=testEtagFlag
+        #myServer.me="HELLO"
+        
+        print( "Serving Redfish mockup on port: {}".format(port))
         sys.stdout.flush()
         try:
                 myServer.serve_forever()

--- a/redfishMockupServer/redfishMockupServer.py
+++ b/redfishMockupServer/redfishMockupServer.py
@@ -130,10 +130,10 @@ def main(argv):
         
         try:
                 opts, args = getopt.getopt(argv[1:],"hLH:P:",["help","Load","Host=","Port="])
-        except getopt.GetoptError as err:
+        except getopt.GetoptError:
                 #usage()
-                print(err)
-                usage()
+                print("Error parsing options")
+                usage(program)
                 sys.exit(2)
 
         for opt, arg in opts:
@@ -153,9 +153,11 @@ def main(argv):
         print ('program: ', program)
         print ('Hostname:', hostname)
         print ('Port:', port)
+        sys.stdout.flush()
 
         myServer=HTTPServer((hostname, port), RfMockupServer)
         print( 'Serving Redfish mockup on port:', port)
+        sys.stdout.flush()
         try:
                 myServer.serve_forever()
         except KeyboardInterupt:
@@ -163,6 +165,7 @@ def main(argv):
 
         myServer.server_close()
         print("Shutting down http server")
+        sys.stdout.flush()
         
 
 # the below is only executed if the program is run as a script


### PR DESCRIPTION
enhancements to 0.9.1      (this PR is into 0.9.1, which then could be merged into master?)
+- added flush to server prints so that buffered stdout on cygwin would work
 +- added -T option to enable returning fake etags on certain APIs -instead of always doing it
 +- added -D <dir>  option  where <dir> is the abs or relative path to the mockup.  if no -D option, then CWD is assumed