### PR TITLE
Added support for generating JSON definitions for schemas that only define referenceable members

### DIFF
--- a/csdl-to-json-convertor/service.py
+++ b/csdl-to-json-convertor/service.py
@@ -1569,6 +1569,9 @@ class JsonSchemaGenerator:
                     # todo: support other versions (derived) of Resource and ReferenceableMember
                     elif ( basetype == "Resource.v1_0_0.Resource" ):
                         output += self.generate_json_for_reference_type(typetable, typename, namespace, depth + 1, prefixuri, True)
+                    elif ( basetype == "Resource.v1_0_0.ReferenceableMember" ) and ( currentNamespace == typename ):
+                        # In this case, we have a schema with the sole purpose of defining a ReferenceableMember (like Redundancy)
+                        output += self.generate_json_for_reference_type(typetable, typename, namespace, depth + 1, prefixuri, True)
                     elif ( self.isabstract(typedata) ):
                         output += self.generate_json_for_reference_type(typetable, typename, namespace, depth + 1, prefixuri, False)
                     else:


### PR DESCRIPTION
Currently only Redundancy_v1.xml hits this issue, so this will correct the generation of Redundancy.json.