### PR TITLE
Added support for processing Redfish.Deprecated on enum members

### DIFF
--- a/csdl-to-json-convertor/service.py
+++ b/csdl-to-json-convertor/service.py
@@ -1155,6 +1155,7 @@ class JsonSchemaGenerator:
             firstenumvalue = True
             founddescriptions=False
             foundlongdescriptions=False
+            founddeprecated=False
 
             for member in members:
                 if firstenumvalue:
@@ -1170,6 +1171,9 @@ class JsonSchemaGenerator:
 
                 if member["LongDescription"] != "":
                    foundlongdescriptions = True
+
+                if member["Deprecated"] != "":
+                   founddeprecated = True
 
             output += "\n"
             output += UT.Utilities.indent(depth) + "]"
@@ -1210,6 +1214,24 @@ class JsonSchemaGenerator:
                 output += "\n"
                 output += UT.Utilities.indent(depth)  + "}"
 
+            if founddeprecated:
+                output += ",\n"
+                output += UT.Utilities.indent(depth) + "\"enumDeprecated\": {\n"
+                firstenumvalue = True
+
+                for member in members:
+                    if member["Deprecated"] != "":
+                        if firstenumvalue:
+                            firstenumvalue = False
+
+                        else:
+                            output += ",\n"
+
+                        output += UT.Utilities.indent(depth+1) + "\"" + member["Name"] + "\": \"" + member["Deprecated"] + "\""
+
+                output += "\n"
+                output += UT.Utilities.indent(depth)  + "}"
+
         return output
 
     ############################################################################################
@@ -1224,13 +1246,16 @@ class JsonSchemaGenerator:
         for member in typedata["Node"].iter("{http://docs.oasis-open.org/odata/ns/edm}Member"):
             description = ""
             longdescription = ""
+            deprecated = ""
             for annotation in member.iter("{http://docs.oasis-open.org/odata/ns/edm}Annotation"):
                 if annotation.attrib["Term"] == "OData.Description":
                    description = annotation.attrib["String"]
                 elif annotation.attrib["Term"] == "OData.LongDescription":
                    longdescription = annotation.attrib["String"]
+                elif annotation.attrib["Term"] == "Redfish.Deprecated":
+                   deprecated = annotation.attrib["String"]
 
-            members.append({"Name":member.attrib["Name"], "Description":description, "LongDescription":longdescription})
+            members.append({"Name":member.attrib["Name"], "Description":description, "LongDescription":longdescription, "Deprecated":deprecated})
 
         return self.generate_enum_type(typetable, typedata, typename, namespace, depth, isnullable, members)
 
@@ -1250,6 +1275,7 @@ class JsonSchemaGenerator:
                         for record in element.iter("{http://docs.oasis-open.org/odata/ns/edm}Record"):
                             description = ""
                             longdescription = ""
+                            deprecated = ""
                             for propertyvalue in record.iter("{http://docs.oasis-open.org/odata/ns/edm}PropertyValue"):
                                 if propertyvalue.attrib["Property"] == "Member":
                                     member = propertyvalue.attrib["String"]
@@ -1260,8 +1286,10 @@ class JsonSchemaGenerator:
                                     description = annotation.attrib["String"]
                                 elif annotation.attrib["Term"] == "OData.LongDescription":
                                     longdescription = annotation.attrib["String"]
+                                elif annotation.attrib["Term"] == "Redfish.Deprecated":
+                                    deprecated = annotation.attrib["String"]
 
-                            members.append({"Name":member,"Description":description,"LongDescription":longdescription})
+                            members.append({"Name":member,"Description":description,"LongDescription":longdescription,"Deprecated":deprecated})
                     break
             break
 

--- a/csdl-to-json-convertor/service.py
+++ b/csdl-to-json-convertor/service.py
@@ -32,7 +32,7 @@ if enable_debugging == True:
 schemaLocation = "http://redfish.dmtf.org/schemas/" 
 schemaBaseLocation = schemaLocation + "v1/"
 odataSchema = schemaBaseLocation + "odata.4.0.0.json"
-redfishSchema = schemaLocation + "v1/redfish-schema.v1_1_0.json"
+redfishSchema = schemaLocation + "v1/redfish-schema.v1_2_0.json"
 
 #########################################################################################################
 # Class Name: JsonSchemaGenerator                                                                       #


### PR DESCRIPTION
Adds the property "enumDeprecated" to the definition for an enum. For example...

```
        "LineInputVoltageType": {
            "type": "string",
            "enum": [
                "Unknown",
                "ACLowLine",
                "ACMidLine",
                "ACHighLine",
                "DCNeg48V",
                "DC380V",
                "AC120V",
                "AC240V",
                "AC277V",
                "ACandDCWideRange",
                "ACWideRange",
                "DC240V"
            ],
            "enumDescriptions": {
                "Unknown": "The power supply line input voltage type cannot be determined.",
                "ACLowLine": "100-127V AC input. Deprecated: Use AC120V.",
                "ACMidLine": "200-240V AC input. Deprecated: Use AC240V.",
                "ACHighLine": "277V AC input. Deprecated: Use AC277V.",
                "DCNeg48V": "-48V DC input.",
                "DC380V": "High Voltage DC input (380V).",
                "AC120V": "AC 120V nominal input.",
                "AC240V": "AC 240V nominal input.",
                "AC277V": "AC 277V nominal input.",
                "ACandDCWideRange": "Wide range AC or DC input.",
                "ACWideRange": "Wide range AC input.",
                "DC240V": "DC 240V nominal input."
            },
            "enumDeprecated": {
                "ACLowLine": "This value has been Deprecated in favor of AC120V"
            }
```