### PR TITLE
Changed base type check to not assume non-processed entities are valid base types

### DIFF
--- a/csdl-to-json-convertor/service.py
+++ b/csdl-to-json-convertor/service.py
@@ -203,8 +203,9 @@ class JsonSchemaGenerator:
     def has_basetype(self, typetable, type, basetype):
 
         # This is a pre-parsed JSON object. Skip it
+        # This happens for entities we load in stubs
         if "Node" not in type:
-            return True
+            return False
 
         # does it have the base type anywhere in it's hierarchy?
         while True:


### PR DESCRIPTION
Not entirely sure why some of the stubbed references are being cached when processing entities that have no references to them, but this will fix abstract types from inadvertently adding them to their anyOf array when it doesn't make sense to do so.