### PR TITLE
Corrected name of 'target' Action property

### DIFF
--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -593,7 +593,7 @@ pre.code{
             tmp_row = self._add_closing_brace(tmp_row, '')
             rows[-1] = tmp_row
 
-            formatted.append(self.para('The following table shows the parameters for the action which are included in the POST body to the URI shown in the "Target" property of the Action.'))
+            formatted.append(self.para('The following table shows the parameters for the action which are included in the POST body to the URI shown in the "target" property of the Action.'))
 
             formatted.append(self.make_table(rows))
 

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -452,7 +452,7 @@ class MarkdownGenerator(DocFormatter):
             # Add a closing } row:
             rows.append('| ' + ' | '.join(['}', ' ',' ',' ']) + ' |')
 
-            formatted.append(self.para('The following table shows the parameters for the action which are included in the POST body to the URI shown in the "Target" property of the Action.'))
+            formatted.append(self.para('The following table shows the parameters for the action which are included in the POST body to the URI shown in the "target" property of the Action.'))
 
             formatted.append('\n'.join(rows))
 


### PR DESCRIPTION
Had incorrect capitalization of 'target' (shown as 'Target').

Fix #105 