### PR TITLE
Use case-insensitive sort throughout. Fixes #114.

### DIFF
--- a/doc-generator/doc_formatter/csv_generator.py
+++ b/doc-generator/doc_formatter/csv_generator.py
@@ -147,7 +147,7 @@ class CsvGenerator(DocFormatter):
 
         enumerations = ''
         if 'enum' in p_i:
-            p_i['enum'].sort()
+            p_i['enum'].sort(key=str.lower)
             enumerations = ', '.join(p_i['enum'])
 
         schema_name = self.schema_name

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -278,7 +278,7 @@ class DocFormatter:
         profile_mode = config.get('profile_mode')
 
         schema_keys = self.documented_schemas
-        schema_keys.sort()
+        schema_keys.sort(key=str.lower)
 
         for schema_ref in schema_keys:
             details = property_data[schema_ref]
@@ -354,13 +354,13 @@ class DocFormatter:
 
                 if len(prop_details):
                     detail_names = [x for x in prop_details.keys()]
-                    detail_names.sort()
+                    detail_names.sort(key=str.lower)
                     for detail_name in detail_names:
                         self.add_property_details(prop_details[detail_name])
 
                 if len(conditional_details):
                     cond_names = [x for x in conditional_details.keys()]
-                    cond_names.sort()
+                    cond_names.sort(key=str.lower)
                     for cond_name in cond_names:
                         self.add_profile_conditional_details(conditional_details[cond_name])
 
@@ -428,7 +428,7 @@ class DocFormatter:
                 prop_details = {}
                 prop_details.update(formatted['details'])
                 detail_names = [x for x in prop_details.keys()]
-                detail_names.sort()
+                detail_names.sort(key=str.lower)
                 for detail_name in detail_names:
                     frag_gen.add_property_details(prop_details[detail_name])
 
@@ -632,7 +632,7 @@ class DocFormatter:
             prop_names = self.filter_props_by_profile(prop_names, profile)
         prop_names = self.exclude_prop_names(prop_names, self.config['excluded_properties'],
                                        self.config['excluded_by_match'])
-        prop_names.sort()
+        prop_names.sort(key=str.lower)
         return prop_names
 
 
@@ -661,7 +661,7 @@ class DocFormatter:
                 prop_names = filtered
             else:
                 prop_names = list(set(prop_names) & set(profile_props))
-        prop_names.sort()
+        prop_names.sort(key=str.lower)
         return prop_names
 
 
@@ -689,7 +689,7 @@ class DocFormatter:
             if not excluded:
                 included_prop_names.append(prop_name)
 
-        included_prop_names.sort()
+        included_prop_names.sort(key=str.lower)
         return included_prop_names
 
 

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -449,7 +449,7 @@ pre.code{
                 headings.append('Profile Specifies')
             header_row = self.make_header_row(headings)
             table_rows = []
-            enum.sort()
+            enum.sort(key=str.lower)
 
             for enum_item in enum:
                 enum_name = html.escape(enum_item, False)
@@ -506,7 +506,7 @@ pre.code{
                 headings.append('Profile Specifies')
             header_row = self.make_header_row(headings)
             table_rows = []
-            enum.sort()
+            enum.sort(key=str.lower)
             for enum_item in enum:
                 enum_name = html.escape(enum_item, False)
                 enum_item_meta = enum_meta.get(enum_item, {})
@@ -583,7 +583,7 @@ pre.code{
             # Add a "start object" row for this parameter:
             rows.append(self.make_row(['{', '','','']))
             param_names = [x for x in action_parameters.keys()]
-            param_names.sort()
+            param_names.sort(key=str.lower)
             for param_name in param_names:
                 formatted_parameters = self.format_property_row(schema_ref, param_name, action_parameters[param_name], ['Actions', prop_name])
                 rows.append(formatted_parameters.get('row'))
@@ -832,7 +832,7 @@ pre.code{
         terse_mode = self.config.get('profile_mode') == 'terse'
 
         reg_names = [x for x in registry_reqs.keys()]
-        reg_names.sort()
+        reg_names.sort(key=str.lower)
         for reg_name in reg_names:
             reg = registry_reqs[reg_name]
             this_section = {
@@ -849,7 +849,7 @@ pre.code{
 
             msgs = reg.get('Messages', {})
             msg_keys = [x for x in msgs.keys()]
-            msg_keys.sort()
+            msg_keys.sort(key=str.lower)
 
             for msg in msg_keys:
                 this_msg = msgs[msg]

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -314,7 +314,7 @@ class MarkdownGenerator(DocFormatter):
             else:
                 contents.append('| ' + prop_type + ' | Description |')
                 contents.append('| --- | --- |')
-            enum.sort()
+            enum.sort(key=str.lower)
             for enum_item in enum:
                 enum_name = enum_item
                 enum_item_meta = enum_meta.get(enum_item, {})
@@ -444,7 +444,7 @@ class MarkdownGenerator(DocFormatter):
             # Add a "start object" row for this parameter:
             rows.append('| ' + ' | '.join(['{', ' ',' ',' ']) + ' |')
             param_names = [x for x in action_parameters.keys()]
-            param_names.sort()
+            param_names.sort(key=str.lower)
             for param_name in param_names:
                 formatted_parameters = self.format_property_row(schema_ref, param_name, action_parameters[param_name], ['Actions', prop_name])
                 rows.append(formatted_parameters.get('row'))
@@ -670,7 +670,7 @@ search: true
         terse_mode = self.config.get('profile_mode') == 'terse'
 
         reg_names = [x for x in registry_reqs.keys()]
-        reg_names.sort()
+        reg_names.sort(key=str.lower)
         for reg_name in reg_names:
             reg = registry_reqs[reg_name]
             this_section = {
@@ -687,7 +687,7 @@ search: true
 
             msgs = reg.get('Messages', {})
             msg_keys = [x for x in msgs.keys()]
-            msg_keys.sort()
+            msg_keys.sort(key=str.lower)
 
             for msg in msg_keys:
                 this_msg = msgs[msg]


### PR DESCRIPTION
This applies to property names and also the order of schemas (note position of VLanInterface).