### PR TITLE
Improvements to property description overrides

### DIFF
--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -1447,11 +1447,10 @@ class DocFormatter:
                 base_detail_info = properties[prop_name]
                 base_detail_info['prop_required'] = prop_name in parent_requires
                 base_detail_info['prop_required_on_create'] = prop_name in parent_requires_on_create
+                base_detail_info = self.apply_overrides(base_detail_info, schema_name, prop_name)
                 meta = self.merge_metadata(prop_name, base_detail_info.get('_doc_generator_meta', {}), context_meta)
                 detail_info = self.extend_property_info(schema_ref, base_detail_info, meta)
                 meta = self.merge_full_metadata(detail_info[0].get('_doc_generator_meta', {}), meta)
-
-                base_detail_info = self.apply_overrides(base_detail_info, schema_name, prop_name)
 
                 if is_action:
                     # Trim out the properties; these are always Target and Title:

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -312,25 +312,27 @@ pre.code{
                 formatted_details['descr'] += ' '
             formatted_details['descr'] += formatted_details['add_link_text']
 
-        # If there are prop_details (enum details), add a note to the description:
-        if formatted_details['has_direct_prop_details'] and not formatted_details['has_action_details']:
-            if has_enum:
-                anchor = schema_ref + '|details|' + prop_name
-                text_descr = 'See <a href="#' + anchor + '">' + prop_name + '</a> in Property Details, below, for the possible values of this property.'
-            else:
-                text_descr = 'See Property Details, below, for more information about this property.'
+        # Append reference info to descriptions, if appropriate:
+        if not formatted_details.get('fulldescription_override'):
+            # If there are prop_details (enum details), add a note to the description:
+            if formatted_details['has_direct_prop_details'] and not formatted_details['has_action_details']:
+                if has_enum:
+                    anchor = schema_ref + '|details|' + prop_name
+                    text_descr = 'See <a href="#' + anchor + '">' + prop_name + '</a> in Property Details, below, for the possible values of this property.'
+                else:
+                    text_descr = 'See Property Details, below, for more information about this property.'
 
 
-            if formatted_details['descr']:
+                if formatted_details['descr']:
+                    formatted_details['descr'] += '<br>' + self.italic(text_descr)
+                else:
+                    formatted_details['descr'] = self.italic(text_descr)
+
+            # If this is an Action with details, add a note to the description:
+            if formatted_details['has_action_details']:
+                anchor = schema_ref + '|action_details|' + prop_name
+                text_descr = 'For more information, see the <a href="#' + anchor + '">Action Details</a> section below.'
                 formatted_details['descr'] += '<br>' + self.italic(text_descr)
-            else:
-                formatted_details['descr'] = self.italic(text_descr)
-
-        # If this is an Action with details, add a note to the description:
-        if formatted_details['has_action_details']:
-            anchor = schema_ref + '|action_details|' + prop_name
-            text_descr = 'For more information, see the <a href="#' + anchor + '">Action Details</a> section below.'
-            formatted_details['descr'] += '<br>' + self.italic(text_descr)
 
         if deprecated_descr:
             formatted_details['descr'] += ' ' + self.italic(deprecated_descr)

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -204,17 +204,19 @@ class MarkdownGenerator(DocFormatter):
                 formatted_details['descr'] += ' '
             formatted_details['descr'] += formatted_details['add_link_text']
 
-        # If there are prop_details (enum details), add a note to the description:
-        if formatted_details['has_direct_prop_details'] and not formatted_details['has_action_details']:
-            if has_enum:
-                text_descr = 'See ' + prop_name + ' in Property Details, below, for the possible values of this property.'
-            else:
-                text_descr = 'See Property Details, below, for more information about this property.'
-            formatted_details['descr'] += ' ' + self.italic(text_descr)
+        # Append reference info to descriptions, if appropriate:
+        if not formatted_details.get('fulldescription_override'):
+            if formatted_details['has_direct_prop_details'] and not formatted_details['has_action_details']:
+                # If there are prop_details (enum details), add a note to the description:
+                if has_enum:
+                    text_descr = 'See ' + prop_name + ' in Property Details, below, for the possible values of this property.'
+                else:
+                    text_descr = 'See Property Details, below, for more information about this property.'
+                formatted_details['descr'] += ' ' + self.italic(text_descr)
 
-        if formatted_details['has_action_details']:
-            text_descr = 'For more information, see the Action Details section below.'
-            formatted_details['descr'] += ' ' + self.italic(text_descr)
+            if formatted_details['has_action_details']:
+                text_descr = 'For more information, see the Action Details section below.'
+                formatted_details['descr'] += ' ' + self.italic(text_descr)
 
         if deprecated_descr:
             formatted_details['descr'] += ' ' + self.italic(deprecated_descr)

--- a/doc-generator/doc_gen_util/doc_gen_util.py
+++ b/doc-generator/doc_gen_util/doc_gen_util.py
@@ -90,7 +90,6 @@ class DocGenUtilities:
 
         if content:
             urlinfo = urllib.parse.urlparse(uri)
-            # import pdb; pdb.set_trace()
             urlpath = ''.join([urlinfo.scheme, '://', urlinfo.netloc])
 
             m = re.findall('href="([^"]+)"', content)

--- a/doc-generator/doc_generator.py
+++ b/doc-generator/doc_generator.py
@@ -1077,6 +1077,9 @@ def main():
     if 'Description Overrides' in config['supplemental']:
         config['property_description_overrides'] = config['supplemental']['Description Overrides']
 
+    if 'FullDescription Overrides' in config['supplemental']:
+        config['property_fulldescription_overrides'] = config['supplemental']['FullDescription Overrides']
+
     if 'local_to_uri' in config['supplemental']:
         config['local_to_uri'] = config['supplemental']['local_to_uri']
 

--- a/doc-generator/parse_supplement.py
+++ b/doc-generator/parse_supplement.py
@@ -34,6 +34,7 @@ def parse_file(filehandle):
         '# Schema Supplement',     # parse out for schema-specific details (see below)
         '# Schema Documentation',  # list of search/replace patterns for links
         '# Description Overrides', # list of property name:description to substitute throughout the doc
+        '# FullDescription Overrides', # list of property name:description to substitute throughout the doc
         '# Schema URI Mapping',    # map URI(s) to local repo(s)
         '# Profile URI Mapping',   # map URI(s) for profiles to local repo(s)
         '# Enum Deprecations',     # Version and description info for deprecated enums
@@ -75,6 +76,9 @@ def parse_file(filehandle):
 
     if 'Description Overrides' in parsed:
         parsed['Description Overrides'] = parse_description_overrides(parsed['Description Overrides'])
+
+    if 'FullDescription Overrides' in parsed:
+        parsed['FullDescription Overrides'] = parse_description_overrides(parsed['FullDescription Overrides'])
 
     if 'Schema Supplement' in parsed:
         parsed['Schema Supplement'] = parse_schema_supplement(parsed['Schema Supplement'])
@@ -294,6 +298,9 @@ def parse_schema_supplement(markdown_blob):
         if 'description overrides' in parsed[schema_name]:
             parsed[schema_name]['description overrides'] = parse_description_overrides(parsed[schema_name]['description overrides'])
 
+        if 'fulldescription overrides' in parsed[schema_name]:
+            parsed[schema_name]['fulldescription overrides'] = parse_description_overrides(parsed[schema_name]['fulldescription overrides'])
+
     return parsed
 
 
@@ -304,7 +311,8 @@ def parse_schema_details(markdown_blob):
     """
 
     markers = ['### description', '### jsonpayload', '### property details', '### action details',
-               '### schema-intro', '### schema-postscript', '### mockup', '### description overrides']
+               '### schema-intro', '### schema-postscript', '### mockup',
+               '### description overrides', '### fulldescription overrides']
     parsed = {}
     current_marker = None
     bloblines = []

--- a/doc-generator/sample_inputs/usersupplement.md
+++ b/doc-generator/sample_inputs/usersupplement.md
@@ -8,6 +8,7 @@ The supplement is split into several major sections, noted by first-level headin
 - Profile URI Mapping
 - Keyword Configuration
 - Description Overrides
+- FullDescription Overrides
 - Units Translation
 - Enum Deprecations
 - Introduction
@@ -58,7 +59,15 @@ Note: you can specify the location of the TOC, presumably in the Introduction se
 
 # Description Overrides
 
+Replace a property's description. The doc generator will use your definition, and possibly append a reference to further detail (enum details, definition in another schema, common property, etc.)
+
 Note: markdown is allowed in description overrides, but HTML markup is not; it will be escaped.
+
+* SomeProperty: Some description.
+
+# FullDescription Overrides
+
+This is just like Description Overrides, except that *only* the description will be output, with no auto-generated reference.
 
 * Status: See  [The Status Object](#status_description), above.
 

--- a/doc-generator/tests/test_supplement_output.py
+++ b/doc-generator/tests/test_supplement_output.py
@@ -100,11 +100,13 @@ def test_supplement_description_vs_full_html (mockRequest):
     config['output_format'] = 'html'
 
     config['property_description_overrides'] = {
-        "IPv4Address": "This is a description override for the IPv4Address object."
+        "IPv4Address": "This is a description override for the IPv4Address object.",
+        "DeviceId": "This is a description override for DeviceId, which is not a top-level property.",
     }
 
     config['property_fulldescription_overrides'] = {
-        "IPv6Address": "This is a full description override for the IPv6Address object."
+        "IPv6Address": "This is a full description override for the IPv6Address object.",
+        "SubsystemId": "This is a description override for SubsystemId, which is not a top-level property.",
     }
 
     input_dir = os.path.abspath(os.path.join(testcase_path, 'ipaddresses'))
@@ -119,6 +121,8 @@ def test_supplement_description_vs_full_html (mockRequest):
     output_rows = output.split('<tr')
     ipv4_rows = [x for x in output_rows if "<b>IPv4Address</b>" in x]
     ipv6_rows = [x for x in output_rows if "<b>IPv6Address</b>" in x]
+    deviceId_rows = [x for x in output_rows if "<b>DeviceId</b>" in x]
+    subsystemId_rows = [x for x in output_rows if "<b>SubsystemId</b>" in x]
 
     # Verify that the overrides were used:
     ipv4_failed_overrides = [x for x in ipv4_rows if "This is a description override for the IPv4Address object." not in x]
@@ -126,6 +130,12 @@ def test_supplement_description_vs_full_html (mockRequest):
 
     ipv6_failed_overrides = [x for x in ipv6_rows if "This is a full description override for the IPv6Address object." not in x]
     assert len(ipv6_failed_overrides) == 0, "Property full description override failed for " + str(len(ipv6_failed_overrides)) + " mentions of Ipv6Address"
+
+    deviceId_failed_overrides = [x for x in deviceId_rows if "This is a description override for DeviceId" not in x]
+    assert len(deviceId_failed_overrides) == 0, "Property description override failed for " + str(len(deviceId_failed_overrides)) + " mentions of DeviceId"
+
+    subsystemId_failed_overrides = [x for x in subsystemId_rows if "This is a description override for SubsystemId" not in x]
+    assert len(subsystemId_failed_overrides) == 0, "Property description override failed for " + str(len(subsystemId_failed_overrides)) + " mentions of SubsystemId"
 
     # Verify that the description overrides retained the reference to the common property:
     ipv4_failed_overrides = [x for x in ipv4_rows if "for details on this property" not in x]

--- a/doc-generator/tests/test_supplement_output.py
+++ b/doc-generator/tests/test_supplement_output.py
@@ -35,6 +35,10 @@ property_description_overrides = {
     "Oem": "This is a description override for the Oem object."
     }
 
+property_description_full_overrides = {
+    "EndpointProtocol": "This is a full description override for the Oem object."
+    }
+
 base_config = {
     'expand_defs_from_non_output_schemas': False,
     'excluded_by_match': ['@odata.count', '@odata.navigationLink'],
@@ -87,3 +91,46 @@ def test_supplement_output_html (mockRequest):
 
     oem_failed_overrides = [x for x in oem_rows if "This is a description override for the Oem object." not in x]
     assert len(oem_failed_overrides) == 0, "Property description override failed for " + str(len(oem_failed_overrides)) + " mentions of Oem"
+
+
+@patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
+def test_supplement_description_vs_full_html (mockRequest):
+
+    config = copy.deepcopy(base_config)
+    config['output_format'] = 'html'
+
+    config['property_description_overrides'] = {
+        "IPv4Address": "This is a description override for the IPv4Address object."
+    }
+
+    config['property_fulldescription_overrides'] = {
+        "IPv6Address": "This is a full description override for the IPv6Address object."
+    }
+
+    input_dir = os.path.abspath(os.path.join(testcase_path, 'ipaddresses'))
+
+    config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
+    config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
+
+    docGen = DocGenerator([ input_dir ], '/dev/null', config)
+    output = docGen.generate_docs()
+
+    # Chop into rows. We just want to find the IPv4Address and IPv6Address rows.
+    output_rows = output.split('<tr')
+    ipv4_rows = [x for x in output_rows if "<b>IPv4Address</b>" in x]
+    ipv6_rows = [x for x in output_rows if "<b>IPv6Address</b>" in x]
+
+    # Verify that the overrides were used:
+    ipv4_failed_overrides = [x for x in ipv4_rows if "This is a description override for the IPv4Address object." not in x]
+    assert len(ipv4_failed_overrides) == 0, "Property description override failed for " + str(len(ipv4_failed_overrides)) + " mentions of Ipv4Address"
+
+    ipv6_failed_overrides = [x for x in ipv6_rows if "This is a full description override for the IPv6Address object." not in x]
+    assert len(ipv6_failed_overrides) == 0, "Property full description override failed for " + str(len(ipv6_failed_overrides)) + " mentions of Ipv6Address"
+
+    # Verify that the description overrides retained the reference to the common property:
+    ipv4_failed_overrides = [x for x in ipv4_rows if "for details on this property" not in x]
+    assert len(ipv4_failed_overrides) == 0, "Property description override failed to include reference to common property for " + str(len(ipv4_failed_overrides)) + " mentions of Ipv4Address"
+
+    # Verify that the full description overrides DID NOT retain the reference to the common property:
+    ipv6_failed_overrides = [x for x in ipv6_rows if "for details on this property" in x]
+    assert len(ipv6_failed_overrides) == 0, "Property full description override incorrectly included reference to common property " + str(len(ipv6_failed_overrides)) + " mentions of Ipv6Address"

--- a/doc-generator/tests/test_version_deprecated.py
+++ b/doc-generator/tests/test_version_deprecated.py
@@ -64,7 +64,7 @@ def test_version_deprecated_metadata(mockRequest):
     docGen = DocGenerator([ input_dir ], '/dev/null', config)
     output = docGen.generate_docs()
     meta = docGen.property_data['redfish.dmtf.org/schemas/v1/Event.json']['doc_generator_meta']
-    import pdb; pdb.set_trace()
+
     discrepancies = DiscrepancyList()
     for name, data in expected_versions.items():
         if name == 'version': continue


### PR DESCRIPTION
This addresses: 

> Allow complete description text replacement for Properties and a
> description override tag that indicates the doc generator should use
> this description text “as is” for final output in both full schemas
> and schema fragments.
> 
> Ensure description text replacement works within JSON objects as well
> as at the root level.

Complete description text replacement can be specified in a "FullDescription Overrides" section in the supplemental markdown fed to the doc generator. Semantics are identical to the "Description Overrides" section. 