### PR TITLE
Fix doc_generator README file

### DIFF
--- a/doc-generator/README.md
+++ b/doc-generator/README.md
@@ -1,36 +1,40 @@
 # Redfish Documentation Generator
 
-Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+Copyright 2016-2018 Distributed Management Task Force, Inc. All rights reserved.
 
 ## About
 
-The Documentation Generator is a python tool that parses a set of JSON schema files (typically the entire set for a version) and generates a markdown document.
+The `doc_generator` is a Python tool that parses a set of JSON schema files (typically the entire set for a version) and generates a Markdown document.
 
-Output is GitHub-flavored markdown targeted for the Slate documentation tool (https://github.com/tripit/slate).
+Output is GitHub-flavored Markdown targeted for the [Slate API docs generator](https://github.com/tripit/slate).
 
 ## Installation
 
-* Ensure that the machine running the tool has python3 installed. For markdown output, only the standard library is required.
-* For HTML output, python-markdown and Pygments must also be installed:
-  * python-markdown: https://pythonhosted.org/Markdown/install.html
-  * Pygments: http://pygments.org/
+1. Install the following required software on the machine from which you will run the `doc_generator`: 
 
-If you are using pip:
+    | Software | Description | Download |
+    |----------|-------------|----------|
+    | Python 3 | For Markdown output, install only the standard library. | [https://www.python.org/downloads/](https://www.python.org/downloads/) |
+    | Python&#8209;Markdown | Required for HTML output. | [https://python-markdown.github.io/install/](https://python-markdown.github.io/install/) |
+    | Pygments | Required for HTML output. | [http://pygments.org/](http://pygments.org/) |
 
-```
-% pip install -r requirements.txt
-```
+1. Verify the installation of requirements. If you use `pip`:
+ 
+    ```
+    % cd doc-generator
+    % pip install -r requirements.txt
+    ```
 
 ## Usage
 
-By default, doc_generator will look for a json-schema directory and
-supplement file in the directory from which it is run. Alternatively,
-you can specify these locations on the command line.
+By default, `doc_generator` looks for a `json-schema` directory and
+supplement file in the directory from where you run it. Alternatively,
+you can specify the locations of the `json-schema` directory and
+supplement file on the command line.
 
 You must also specify a mapping from schema URIs to local directories.
-The doc_generator tool uses this information to determine whether to get
-referenced data from local files, or to attempt to retrieve it over the
-internet. See "The Supplemental File," below.
+The `doc_generator` tool uses this information to determine whether to get
+referenced data from local files or over the Internet. See [The Supplemental Material Document](#the-supplemental-material-document).
 
 ```
 usage: doc_generator.py [-h] [-n] [--format {markdown,html}] [--out OUTFILE]
@@ -41,29 +45,29 @@ usage: doc_generator.py [-h] [-n] [--format {markdown,html}] [--out OUTFILE]
 Generate documentation for Redfish JSON schema files.
 
 positional arguments:
-  import_from           Name of a file or directory to process (wildcards are
-                        acceptable).Default: json-schema
+  import_from           Name of a file or directory to process (wild cards are
+                        acceptable). Default: json-schema
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit
   -n, --normative       Produce normative (developer-focused) output
   --format {markdown,html}
                         Output format
   --out OUTFILE         Output file (default depends on output format:
-                        output.md for markdown, index.html for html)
+                        output.md for Markdown, index.html for HTML)
   --sup SUPFILE         Path to the supplemental material document. Default is
                         usersupplement.md for user-focused documentation, and
                         devsupplement.md for normative documentation.
   --profile PROFILE_DOC
-                        Path to a JSON profile document, for profile output
+                        Path to a JSON profile document, for profile output.
   -t, --terse           Terse output (meaningful only with --profile). By
-                        default,profile output is verbose, including all
-                        properties regardless ofprofile requirements. "Terse"
-                        output is intended for use byService developers,
-                        including only the subset of properties withprofile
+                        default, profile output is verbose and includes all
+                        properties regardless of profile requirements. "Terse"
+                        output is intended for use by service developers,
+                        including only the subset of properties with profile
                         requirements.
   --escape ESCAPE_CHARS
-                        Characters to escape (\) in generated markdown; e.g.,
+                        Characters to escape (\) in generated Markdown. For example,
                         --escape=@#. Use --escape=@ if strings with embedded @
                         are being converted to mailto links.
 
@@ -72,17 +76,12 @@ Example:
    doc_generator.py --format=html --out=/path/to/output/index.html /path/to/spmf/json-files
 ```
 
-Normative output prefers longDescriptions to descriptions.
+Normative output prefers long descriptions to descriptions.
 
-For Slate, place the output index.html.md in your Slate repository's source directory.
+For Slate, place the `index.html.md` output in your Slate repository's source directory.
 
 ## The Supplemental Material Document
 
-usersupplement.md in this directory is an example of a supplemental
-material document. It includes explanations of each type of
-information you can include in the supplement.
+The `doc-generator/sample_inputs/excerpt/usersupplement.md` file is an example of a supplemental material document. It describes each information type that you can include in the supplement.
 
-The most important element of the supplemental document is the *Schema
-URI Mapping* section. In this section, you identify partial URIs that
-map to local directories, directing the doc_generator to look in the
-specified local directory when following references in a schema.
+The most important section of this document is *Schema URI Mapping*, which describes how to map schema URIs to local files. You define and map partial URIs to local directories. The `doc_generator` uses the specified local files, if any. Otherwise, the `doc_generator` follows the full URI, including data from remote files, if possible.


### PR DESCRIPTION
Updated README to:

* Correct location for Python Markdown.
* Clarify which directory you must be in to run requirements.txt.
* Fix some typos.
* Clarify location of usersupplement.md.

@jautor 