### PR TITLE
added  error info re where in xml parse error was, and support for relative url inside xml files

### DIFF
--- a/odata-csdl-validator/odata_validator.py
+++ b/odata-csdl-validator/odata_validator.py
@@ -1397,8 +1397,9 @@ class MetaData(Element):
                 try:
                     self.data = ET.parse(local_directory + os.path.sep + filename)
                     self.raw_data = self.data.getroot()
-                except Exception:
-                    print("Could not open " + local_directory + os.path.sep + filename)
+                except Exception as error:
+                    print("Error Opening or parsing schema file: {}".format(local_directory + os.path.sep + filename))
+                    print("  Exception: {}".format(error))
                     sys.exit(0)
             # If not available, go open via HTTP
             else:
@@ -1412,10 +1413,10 @@ class MetaData(Element):
                         self.raw_data = ET.fromstring(self.data)
                         self.rootUri=self.uri
                         break
-                    except Exception as e:
-                        if e.errno != errno.ECONNRESET:
-                            print("Could not open " + self.uri)
-                            print( e )
+                    except Exception as error:
+                        if error.errno != errno.ECONNRESET:
+                            print("Error Opening or parsing schema file: {}".format(self.uri))
+                            print("  Exception: {}".format(error))
                             sys.exit(0)
                     retry_count += 1
                 if retry_count >= retry_count_max:

--- a/odata-csdl-validator/odata_validator.py
+++ b/odata-csdl-validator/odata_validator.py
@@ -1414,7 +1414,7 @@ class MetaData(Element):
                         break
                     except Exception as e:
                         if e.errno != errno.ECONNRESET:
-                            print("ee Could not open " + self.uri)
+                            print("Could not open " + self.uri)
                             print( e )
                             sys.exit(0)
                     retry_count += 1


### PR DESCRIPTION
Two extensions:
1) added additional error output when an xml file cant be parsed.
    --prints the exception error info
    --if its bad xml syntax, it tells the line and column where the syntax failed
2) handles relative links inside an xml csdl file.
    eg:    I am valicating  https://github/pathTo/IntelRackScaleOem.xml which contains links to many more schemas in the remote directory path as the root file I am validating.  Its links look like:
   <edmx:Reference Uri="Resource_v1.xml">  where the assumption is Resource_v1.xml
   I see other oem csdl files with internal links eg /redfish/v1/Schemastore/Resource_v1.xml
   where the referenced links are under the same <scheme>/<netloc>/.  This should work for them too.
  The current change only applies if the target starts with http.
   It explicitly does not impact case where target is a folder.
    The change is to join the links to the root link with urllib.parse.urljoin for the case where the
      root url was http*.   
    Tested with some RackScale oem files on github