### PR TITLE
Fix a bug wherein enums were dropped for some properties of common objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /csdl-to-json-convertor/json
 /*/__pycache__
 .DS_Store
+*.pyc

--- a/doc-generator/doc_generator.py
+++ b/doc-generator/doc_generator.py
@@ -777,12 +777,11 @@ class DocGenerator:
                                             prop_ref = elt['$ref']
                                         if elt['$ref'].startswith('#'):
                                             prop_ref = this_schema + elt['$ref']
-                            if prop_ref:
-                                del(ref_properties[prop_name]['anyOf'])
 
                         if prop_ref:
                             child_ref = traverser.find_ref_data(prop_ref)
                             if child_ref and 'properties' in child_ref:
+                                del(ref_properties[prop_name]['anyOf']) # We're replacing this.
                                 child_ref_properties = child_ref['properties']
                                 meta[prop_name] = self.extend_metadata(meta[prop_name], child_ref_properties, this_version,
                                                                        this_ref + '/prop_name#properties')


### PR DESCRIPTION
This affected definitions in schemas that were not versioned at the "top" object for the file, but
rather at individual properties or definitions, and that further had an "anyOf" specifying a definition
that went straight to an enum. More generally, this would probably affect any pointer to a definition that
did not specify an object with properties. Example: AddressOrigin in IPAddresses/IPv4Address.