### PR TITLE
Fix an issue affecting docs for the 2018.3 schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ language: python
 python:
  - "3.5"
  - "3.6"
+ - "3.7-dev"
 install: true
 env:
  - TEST_DIR=doc-generator

--- a/doc-generator/Pipfile
+++ b/doc-generator/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [requires]
-python_version = "3.5"
+python_version = "3.7"
 
 [dev-packages]
 pytest = "*"


### PR DESCRIPTION
Schema traverser didn't have data to get to some properties defined in the unversioned schemas. Now it does. 

(There's also a little unrelated updated config here for my Mac and travis.) 