### PR TITLE
Doc generator: include json payloads from a specified directory (fixes #127)

### DIFF
--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -347,6 +347,15 @@ class DocFormatter:
             supplemental = schema_supplement.get(schema_key,
                                                  schema_supplement.get(schema_name, {}))
 
+            json_payload = None
+            if self.config.get('payloads'):
+                payload_key = DocGenUtilities.get_payload_name(schema_name, version)
+                payload = self.config['payloads'].get(payload_key)
+                if payload:
+                    json_payload = '```json\n' + payload.strip() + '\n```\n'
+            else:
+                json_payload = supplemental.get('jsonpayload')
+
             definitions = details['definitions']
 
             if config.get('omit_version_in_headers'):
@@ -395,7 +404,7 @@ class DocFormatter:
             if details.get('release_history'):
                 self.add_release_history(details['release_history'])
 
-            self.add_json_payload(supplemental.get('jsonpayload'))
+            self.add_json_payload(json_payload)
 
             if 'properties' in details.keys():
                 prop_details = {}

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -914,7 +914,6 @@ pre.code{
 
         This may include comments as well as a ```json block. """
         if json_payload:
-
             self.this_section['json_payload'] = ('<div class="json-payload">' +
                                                  self.formatter.markdown_to_html(json_payload) + '</div>')
         else:

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -909,15 +909,10 @@ pre.code{
         return uri_highlighted
 
 
-    def add_json_payload(self, json_payload):
-        """ Add a JSON payload for the current section
-
-        This may include comments as well as a ```json block. """
-        if json_payload:
-            self.this_section['json_payload'] = ('<div class="json-payload">' +
-                                                 self.formatter.markdown_to_html(json_payload) + '</div>')
-        else:
-            self.this_section['json_payload'] = None
+    def format_json_payload(self, json_payload):
+        """ Format a json payload for output. """
+        return ('<div class="json-payload">' +
+                    self.formatter.markdown_to_html(json_payload) + '</div>')
 
 
     def add_property_row(self, formatted_text):

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -39,6 +39,7 @@ class MarkdownGenerator(DocFormatter):
             'pattern': ', '
             }
         self.formatter = FormatUtils()
+        self.layout_payloads = 'top'
 
 
     def format_property_row(self, schema_ref, prop_name, prop_info, prop_path=[], in_array=False):
@@ -710,12 +711,9 @@ search: true
         return uri_block
 
 
-    def add_json_payload(self, json_payload):
-        """ Add a JSON payload for the current section """
-        if json_payload:
-            self.this_section['json_payload'] = '\n' + json_payload + '\n'
-        else:
-            self.this_section['json_payload'] = None
+    def format_json_payload(self, json_payload):
+        """ Format a json payload for output. """
+        return '\n' + json_payload + '\n'
 
 
     def add_property_row(self, formatted_text):

--- a/doc-generator/doc_gen_util/doc_gen_util.py
+++ b/doc-generator/doc_gen_util/doc_gen_util.py
@@ -169,3 +169,16 @@ class DocGenUtilities:
             version_string = match.group(1)
             version_string = version_string.replace('_', '.')
         return version_string
+
+
+    @staticmethod
+    def get_payload_name(schema_name, version, action_name=None):
+
+        major_version = version.split('.')[0]
+        payload_name = schema_name + '-v' + major_version + '-'
+        if action_name:
+            payload_name += 'action-' + action_name + '.json'
+        else:
+            payload_name += 'example.json'
+
+        return payload_name

--- a/doc-generator/tests/samples/payloads/ActionInfo-v1-example.json
+++ b/doc-generator/tests/samples/payloads/ActionInfo-v1-example.json
@@ -1,0 +1,25 @@
+{
+    "@odata.type": "#ActionInfo.v1_1_0.ActionInfo",
+    "Id": "ResetActionInfo",
+    "Name": "Reset Action Info",
+    "Parameters": [
+        {
+            "Name": "ResetType",
+            "Required": true,
+            "DataType": "String",
+            "AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton"
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#ActionInfo.ActionInfo",
+    "@odata.id": "/redfish/v1/Systems/1/ResetActionInfo"
+}

--- a/doc-generator/tests/samples/payloads/LogService-v1-example.json
+++ b/doc-generator/tests/samples/payloads/LogService-v1-example.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#LogService.v1_1_1.LogService",
+    "Id": "Log1",
+    "Name": "System Log Service",
+    "Description": "This log contains entries related to the operation of the host Computer System.",
+    "MaxNumberOfRecords": 1000,
+    "OverWritePolicy": "WrapsWhenFull",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "ServiceEnabled": true,
+    "LogEntryType": "Event",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Managers/1/LogServices/Log1/Actions/LogService.ClearLog"
+        },
+        "Oem": {}
+    },
+    "Entries": {
+        "@odata.id": "/redfish/v1/Managers/1/LogServices/Log1/Entries"
+    },
+    "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices/Log1"
+}

--- a/doc-generator/tests/samples/payloads/Memory-v1-example.json
+++ b/doc-generator/tests/samples/payloads/Memory-v1-example.json
@@ -1,0 +1,31 @@
+{
+    "@odata.type": "#Memory.v1_6_0.Memory",
+    "Id": "DIMM1",
+    "Name": "DIMM Slot 1",
+    "RankCount": 2,
+    "MaxTDPMilliWatts": [
+        12000
+    ],
+    "CapacityMiB": 32768,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "ErrorCorrection": "MultiBitECC",
+    "MemoryLocation": {
+        "Socket": 1,
+        "MemoryController": 1,
+        "Channel": 1,
+        "Slot": 1
+    },
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "BaseModuleType": "RDIMM",
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM1"
+}

--- a/doc-generator/tests/samples/payloads/SomeOtherFile.txt
+++ b/doc-generator/tests/samples/payloads/SomeOtherFile.txt
@@ -1,0 +1,1 @@
+This is a file the payload slurper should ignore. 

--- a/doc-generator/tests/test_payload_directory.py
+++ b/doc-generator/tests/test_payload_directory.py
@@ -1,0 +1,54 @@
+# Copyright Notice:
+# Copyright 2019 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tools/blob/master/LICENSE.md
+
+"""
+File: test_payload_directory.py
+
+Brief: test(s) for retrieving payload examples from the "payload_dir" option.
+"""
+
+import os
+from unittest.mock import patch
+import pytest
+from doc_generator import DocGenerator
+from doc_gen_util import DocGenUtilities
+
+testcase_path = os.path.join('tests', 'samples')
+
+base_config = {
+    'expand_defs_from_non_output_schemas': False,
+    'excluded_by_match': ['@odata.count', '@odata.navigationLink'],
+    'profile_resources': {},
+    'units_translation': {},
+    'excluded_annotations_by_match': ['@odata.count', '@odata.navigationLink'],
+    'excluded_schemas': [],
+    'excluded_properties': ['@odata.id', '@odata.context', '@odata.type'],
+    'uri_replacements': {},
+    'payload_dir': os.path.join('tests', 'samples', 'payloads'),
+    'profile': {},
+    'escape_chars': [],
+
+    'output_format': 'markdown',
+}
+
+
+def test_payloads_read_directory():
+    input_dir = os.path.abspath(testcase_path) # This test won't actually use the files in this directory.
+    docGen = DocGenerator([ input_dir ], '/dev/null', base_config)
+
+    expected_filenames = ['LogService-v1-example.json', 'ActionInfo-v1-example.json',
+                              'Memory-v1-example.json']
+
+    read_filenames = docGen.config['payloads'].keys()
+    assert len(read_filenames) == 3
+    for f in expected_filenames:
+        assert f in read_filenames
+
+
+def test_payloads_lookup():
+    payload_name = DocGenUtilities.get_payload_name('LogService', '1.3.1')
+    assert payload_name == 'LogService-v1-example.json'
+
+    payload_name = DocGenUtilities.get_payload_name('LogService', '1.3.1', 'GoFish')
+    assert payload_name == 'LogService-v1-action-GoFish.json'


### PR DESCRIPTION
Implemented just as described in the issue. Payloads for Action examples are a new feature; they are simply included with the Action details -- immediately above in the case of markdown output; immediately below for HTML output. 