### PR TITLE
Updates to doc generator -- Property Index boilerplate and better URI formatting

### DIFF
--- a/doc-generator/README_Property_Index.md
+++ b/doc-generator/README_Property_Index.md
@@ -29,6 +29,12 @@ optional arguments:
   --out OUTFILE         Output file (default depends on output format:
                         output.md for Markdown, index.html for HTML,
                         output.csv for CSV
+  --sup SUPFILE         Path to the supplemental material document. For
+                        Property Index mode, this document should simply be
+                        an HTML or markdown file containing any content
+                        you want to include before/after the property index, and
+                        a marker "[insert property index]" where the property index
+                        output should go.
   --config CONFIG_FILE  Path to a config file, containing configuration in
                         JSON format. Used in property_index mode only.
 

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -123,6 +123,11 @@ class DocFormatter:
         return uri_highlighted
 
 
+    def format_uris_for_table(self, uris):
+        """ Format a bunch of uris to go into a table cell """
+        return '<br>'.join([self.format_uri(x) for x in sorted(uris, key=str.lower)])
+
+
     def format_json_payload(self, json_payload):
         """ Format a json payload for output. """
         return json_payload
@@ -634,7 +639,7 @@ class DocFormatter:
         header = self.formatter.make_header_row(['Collection Type', 'URIs'])
         rows = []
         for collection_name, uris in sorted(collections_uris.items(), key=lambda x: x[0].lower()):
-            item_text = '<br>'.join([self.format_uri(x) for x in sorted(uris, key=str.lower)])
+            item_text = self.format_uris_for_table(uris)
             rows.append(self.formatter.make_row([collection_name, item_text]))
         doc = self.formatter.make_table(rows, [header], 'uris')
         return doc

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -1290,7 +1290,7 @@ class DocFormatter:
                 formatted_action = self.format_property_row(schema_ref, param_name, action_parameters[param_name], new_path)
 
                 # Capture the enum details and merge them into the ones for the overall properties:
-                if formatted_action.get('details'):
+                if formatted_action and formatted_action.get('details'):
                     has_prop_details = True
                     prop_details.update(formatted_action['details'])
 

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -650,7 +650,7 @@ class DocFormatter:
             [preamble, collection_file_name] = x.rsplit('/', 1)
             [collection_name, rest] = collection_file_name.split('.', 1)
             uris = sorted(self.property_data[x].get('uris', []), key=str.lower)
-            data[collection_name] = [self.format_uri(x) for x in uris]
+            data[collection_name] = uris
         return data
 
 

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -77,9 +77,6 @@ class HtmlGenerator(DocFormatter):
 table.properties{
     width: 100%;
 }
-table.uris tr td:nth-child(2) {
-    word-break: break-all;
-}
 .property-details-content {
     margin-left: 5em;
 }
@@ -916,6 +913,7 @@ pre.code{
         uri_strings = []
         for uri in sorted(uris, key=str.lower):
             uri = uri + "/Actions/" + action
+            uri = uri.replace('/', '/\u200b')
             uri_strings.append('<li>' + self.format_uri(uri) + '</li>')
 
         uri_block = '<ul class="nobullet">' + '\n'.join(uri_strings) + '</ul>'
@@ -925,6 +923,7 @@ pre.code{
 
     def format_uri(self, uri):
         """ Format a URI for output. Includes creating links to Id'd schemas """
+
         uri_parts = uri.split('/')
         uri_parts_highlighted = []
         for part in uri_parts:
@@ -938,7 +937,7 @@ pre.code{
                 # and italicize it
                 part = self.formatter.italic(part)
             uri_parts_highlighted.append(part)
-        uri_highlighted = '/'.join(uri_parts_highlighted)
+        uri_highlighted = '/\u200b'.join(uri_parts_highlighted)
         return uri_highlighted
 
 

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -54,6 +54,10 @@ class HtmlGenerator(DocFormatter):
  }
  ul, ol {margin-left: 2em;}
  li {margin: 0 0 0.5em;}
+ .hanging-indent {
+      padding-left: 1em;
+      text-indent: -1em;
+ }
  p {margin: 0 0 0.5em;}
  div.toc {margin: 0 0 2em 0;}
  .toc ul {list-style-type: none;}
@@ -901,7 +905,7 @@ pre.code{
         """ Add the URIs (which should be a list) """
         uri_strings = []
         for uri in sorted(uris, key=str.lower):
-            uri_strings.append('<li>' + self.format_uri(uri) + '</li>')
+            uri_strings.append('<li class="hanging-indent">' + self.format_uri(uri) + '</li>')
 
         uri_block = '<ul class="nobullet">' + '\n'.join(uri_strings) + '</ul>'
         uri_content = '<h4>URIs:</h4>' + uri_block
@@ -914,7 +918,7 @@ pre.code{
         for uri in sorted(uris, key=str.lower):
             uri = uri + "/Actions/" + action
             uri = uri.replace('/', '/\u200b')
-            uri_strings.append('<li>' + self.format_uri(uri) + '</li>')
+            uri_strings.append('<li class="hanging-indent">' + self.format_uri(uri) + '</li>')
 
         uri_block = '<ul class="nobullet">' + '\n'.join(uri_strings) + '</ul>'
         uri_content = '<h5>URIs:</h5>' + uri_block
@@ -939,6 +943,12 @@ pre.code{
             uri_parts_highlighted.append(part)
         uri_highlighted = '/\u200b'.join(uri_parts_highlighted)
         return uri_highlighted
+
+
+    def format_uris_for_table(self, uris):
+        """ Format a bunch of uris to go into a table cell """
+        return ''.join(['<div class="hanging-indent">' + self.format_uri(x) + '</div>'
+                            for x in sorted(uris, key=str.lower)])
 
 
     def format_json_payload(self, json_payload):

--- a/doc-generator/doc_formatter/property_index_generator.py
+++ b/doc-generator/doc_formatter/property_index_generator.py
@@ -74,18 +74,30 @@ class PropertyIndexGenerator(DocFormatter):
         self.coalesce_properties()
         output_format = self.config.get('output_format', 'markdown')
         output = ''
+        frontmatter = backmatter = ''
+        if 'property_index_boilerplate' in self.config:
+            boilerplate = self.config['property_index_boilerplate']
+            frontmatter, backmatter = boilerplate.split('[insert property index]')
         if output_format == 'html':
             from format_utils import HtmlUtils
             formatter = HtmlUtils()
-            output = formatter.head_one("Property Index", 0)
+            if frontmatter:
+                output = frontmatter
+            else:
+                output = formatter.head_one("Property Index", 0)
             output += self.format_tabular_output(formatter)
+            output += backmatter
             output = self.add_html_boilerplate(output)
 
         if output_format == 'markdown':
             from format_utils import FormatUtils
             formatter = FormatUtils()
-            output = formatter.head_one("Property Index", 0)
+            if frontmatter:
+                output = frontmatter
+            else:
+                output = formatter.head_one("Property Index", 0)
             output += self.format_tabular_output(formatter)
+            output += backmatter
 
         if output_format == 'csv':
             output = self.output_csv()

--- a/doc-generator/doc_formatter/property_index_generator.py
+++ b/doc-generator/doc_formatter/property_index_generator.py
@@ -192,6 +192,11 @@ class PropertyIndexGenerator(DocFormatter):
         pass
 
 
+    def format_action_parameters(self, schema_ref, prop_name, prop_descr, action_parameters):
+        """Generate a formatted Actions section from parameters data"""
+        pass
+
+
     def add_registry_reqs(self, registry_reqs):
         """ output doesn't include registry requirements. """
         pass

--- a/doc-generator/doc_generator.py
+++ b/doc-generator/doc_generator.py
@@ -1019,7 +1019,7 @@ def main():
 
     # If property_index mode was specified, get config from args.config_file:
     if config['output_content'] == 'property_index':
-        args.supfile = False
+
         if args.config_file:
             config_file= open(args.config_file, 'r', encoding="utf8")
             config_data = json.load(config_file)
@@ -1034,6 +1034,17 @@ def main():
         else:
             config['property_index_config'] = {'DescriptionOverrides': {},
                                                'ExcludedProperties': []}
+        if args.supfile:
+            try:
+                with open(args.supfile, 'r', encoding="utf8") as supfile:
+                    boilerplate = supfile.read()
+                    if '[insert property index]' in boilerplate:
+                        config['property_index_boilerplate'] = boilerplate
+                    else:
+                        warnings.warn("Supplemental input file lacks the '[insert property index]' marker; ignoring.")
+            except (OSError) as ex:
+                warnings.warn('Unable to open ' + args.supfile + ' to read: ' +  str(ex))
+
 
     else:
         # In any mode other than property_index, we should have a supplemental file.
@@ -1050,6 +1061,7 @@ def main():
         try:
             supfile = open(supfile, 'r', encoding="utf8")
             config['supplemental'] = parse_supplement.parse_file(supfile)
+            supfile.close()
         except (OSError) as ex:
             if supfile_expected:
                 warnings.warn('Unable to open ' + supfile + ' to read: ' +  str(ex))

--- a/doc-generator/tests/samples/referenced_objects/network_sample_output/index.html
+++ b/doc-generator/tests/samples/referenced_objects/network_sample_output/index.html
@@ -40,9 +40,6 @@
 table.properties{
     width: 100%;
 }
-table.uris tr td:nth-child(2) {
-    word-break: break-all;
-}
 .property-details-content {
     margin-left: 5em;
 }

--- a/doc-generator/tests/samples/referenced_objects/network_sample_output/index.html
+++ b/doc-generator/tests/samples/referenced_objects/network_sample_output/index.html
@@ -17,6 +17,10 @@
  }
  ul, ol {margin-left: 2em;}
  li {margin: 0 0 0.5em;}
+ .hanging-indent {
+      padding-left: 1em;
+      text-indent: -1em;
+ }
  p {margin: 0 0 0.5em;}
  div.toc {margin: 0 0 2em 0;}
  .toc ul {list-style-type: none;}

--- a/doc-generator/tests/test_openapi.py
+++ b/doc-generator/tests/test_openapi.py
@@ -158,9 +158,9 @@ def test_uris_in_regular_schema_html_output (mockRequest):
 
     # Links should appear with asterisks around {} path parts to highlight them.
     expected_strings = [
-        '/redfish/v1/Managers/<i>{ManagerId}</i>/LogServices/<i>{LogServiceId}</i>/Entries/<i><a href="#LogEntry">{LogEntryId}</a></i>',
-        '/redfish/v1/Systems/<i>{ComputerSystemId}</i>/LogServices/<i>{LogServiceId}</i>/Entries/<i><a href="#LogEntry">{LogEntryId}</a></i>',
-        '/redfish/v1/CompositionService/ResourceBlocks/<i>{ResourceBlockId}</i>/Systems/<i>{ComputerSystemId}</i>/LogServices/<i>{LogServiceId}</i>/Entries/<i><a href="#LogEntry">{LogEntryId}</a></i>'
+        '/​redfish/​v1/​Managers/​<i>{ManagerId}</i>/​LogServices/​<i>{LogServiceId}</i>/​Entries/​<i><a href="#LogEntry">{LogEntryId}</a></i>',
+        '/​redfish/​v1/​Systems/​<i>{ComputerSystemId}</i>/​LogServices/​<i>{LogServiceId}</i>/​Entries/​<i><a href="#LogEntry">{LogEntryId}</a></i>',
+        '/​redfish/​v1/​CompositionService/​ResourceBlocks/​<i>{ResourceBlockId}</i>/​Systems/​<i>{ComputerSystemId}</i>/​LogServices/​<i>{LogServiceId}</i>/​Entries/​<i><a href="#LogEntry">{LogEntryId}</a></i>'
         ]
 
     for x in expected_strings:


### PR DESCRIPTION
Adds support for a boilerplate input file (--sup argument) in Property Index mode. 

URI formatting improvements in HTML mode include zero-width spaces after slashes, providing reasonable places to break a long line if necessary, and style rules to provide a "hanging indent" appearance when a URI is wrapped. 