### PR TITLE
Allow Edm.Guid values to have upper and lower case A-F characters

### DIFF
--- a/redfish-repo-test/csdl-syntax-test.js
+++ b/redfish-repo-test/csdl-syntax-test.js
@@ -1333,7 +1333,7 @@ function simpleTypeCheck(propType, propValue, CSDLProperty, propName) {
       if(typeof propValue !== 'string' && propValue !== null) {
         throw new Error('Property "'+propName+'" is an Edm.Guid, but the value in the mockup is not a valid JSON string.');
       }
-      if(propValue.match('([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})') === null) {
+      if(propValue.match('([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})') === null) {
         throw new Error('Property "'+propName+'" is an Edm.Guid, but the value in the mockup does not conform to the correct syntax.');
       }
       break;


### PR DESCRIPTION
csdl-syntax-test checks for Edm.Guid validation using the pattern:

`([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})
`

This does not validate against GUIDs that use upper-case A-F letters, such as:
`28D5E212-165B-4CA0-909B-C86B9CEE0112
`

The [Odata spec](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part3-csdl/odata-v4.0-errata03-os-part3-csdl-complete.html#BMABNF) defines Edm.Guid based on the [OData ABNF Construction Rules Spec](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/abnf/odata-abnf-construction-rules.txt , which defines as:

`guidValue = 8HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 12HEXDIG 
`
`HEXDIG = DIGIT / A-to-F`
`A-to-F = "A" / "B" / "C" / "D" / "E" / "F" `

This change allows Edm.Guid values to have both upper and lower case A-F characters