### PR TITLE
Repo test and converter tool updates

### DIFF
--- a/csdl-to-json-convertor/README.md
+++ b/csdl-to-json-convertor/README.md
@@ -40,11 +40,12 @@ optional arguments:
 ### Config File
 
 The config file can contain up to five parameters; parameters not defined will have a default value in the tool:
-  * Copyright: The copyright string to include in the JSON Schema files
-  * RedfishSchema: A pointer to the Redfish extensions to JSON Schema
-  * ODataSchema: A pointer to the OData extensions to JSON Schema
-  * Location: A pointer to the web folder where the resulting JSON Schema files will be published
-  * ResourceLocation: A pointer to the web folder where the core Resource_v1.xml file can be found
+* Copyright: The copyright string to include in the JSON Schema files
+* RedfishSchema: A pointer to the Redfish extensions to JSON Schema
+* ODataSchema: A pointer to the OData extensions to JSON Schema
+* Location: A pointer to the web folder where the resulting JSON Schema files will be published
+* ResourceLocation: A pointer to the web folder where the core Resource_v1.xml file can be found
+* DoNotWrite: A list of the output files to filter out when writing the JSON files
 
 Sample File and Default Values:
 ```
@@ -53,29 +54,30 @@ Sample File and Default Values:
     "RedfishSchema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_2_0.json",
     "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata.4.0.0.json",
     "Location": "http://redfish.dmtf.org/schemas/v1/",
-    "ResourceLocation": "http://redfish.dmtf.org/schemas/v1/"
+    "ResourceLocation": "http://redfish.dmtf.org/schemas/v1/",
+    "DoNotWrite": []
 }
 ```
 
 ## Operation
 
 The tool makes several assumptions about the format of the Redfish CSDL files:
-  * Each file that defines a resource follows the Redfish model for inheritance by copy; other than the base *Resource* definition, each resource definition is contained in one file
-  * Any referenced external namespaces have proper *Include* statements found at the top of the CSL file
-  * All annotations have their expected facets filled; for example, the OData.Description annotation must use the *String=* facet
-  * All namespaces follow the Redfish defined format where a namespace is either unversioned, or is in the form *name.vX_Y_Z*
-  * If a reference is made to another CSDL file, its JSON Schema file will be in the same folder
+* Each file that defines a resource follows the Redfish model for inheritance by copy; other than the base *Resource* definition, each resource definition is contained in one file
+* Any referenced external namespaces have proper *Include* statements found at the top of the CSL file
+* All annotations have their expected facets filled; for example, the OData.Description annotation must use the *String=* facet
+* All namespaces follow the Redfish defined format where a namespace is either unversioned, or is in the form *name.vX_Y_Z*
+* If a reference is made to another CSDL file, its JSON Schema file will be in the same folder
 
 Before any translation is done, the tool will attempt to locate the Resource_v1.xml schema.  This is to cache properties for base definitions that all resources use.  The tool will first check to see if the file exists in the input directory; if it doesn't exist there, it will access the remote location for the file.
 
 Once the Resource_v1.xml definitions are cached, the tool loops on all files ending in ".xml" in the input directory.  For every namespace found in the file, it will generate a corresponding ".json" file in the following manner:
-  * For EntityType and ComplexType definitions...
+* For EntityType and ComplexType definitions...
     * ... that are in an unversioned namespace and are marked as abstract have a definition that contains an "anyOf" statement in the unversioned JSON Schema that points to all versioned definitions
     * ... that are in an unversioned namespace and are not marked as abstract have their definition translated only to the unversioned JSON Schema file
     * ... that are in a versioned namespace have their definitions translated to that version of the JSON Schema file, and newer JSON Schema files
-  * Action definitions...
+* Action definitions...
     * ... that are in an unversioned namespace are translated to all versioned JSON Schema files
     * ... that are in a versioned namespace have their definitions translated to that version of the JSON Schema file, and newer JSON Schema files
-  * EnumType and TypeDefinition definitions...
+* EnumType and TypeDefinition definitions...
     * ... that are in an unversioned namespace are translated to the unversioned JSON Schema file
     * ... that are in a versioned namespace have their definitions translated to that version of the JSON Schema file, and newer JSON Schema files

--- a/csdl-to-json-convertor/csdl-to-json.py
+++ b/csdl-to-json-convertor/csdl-to-json.py
@@ -1434,7 +1434,7 @@ def main():
                     if translator.errors[namespace]:
                         print( "-- Errors detected while generating {}; not creating file".format( out_filename ) )
                     else:
-                        if len( [ i for i in config_data["DoNotWrite"] if i in out_filename_short ] ) == 0:
+                        if len( [ i for i in config_data["DoNotWrite"] if out_filename_short.startswith( i ) ] ) == 0:
                             if overwrite or is_namespace_unversioned( namespace ) or ( not os.path.isfile( out_filename ) ):
                                 out_string = json.dumps( translator.json_out[namespace], sort_keys = True, indent = 4, separators = ( ",", ": " ) )
                                 with open( out_filename, "w" ) as file:

--- a/csdl-to-json-convertor/csdl-to-json.py
+++ b/csdl-to-json-convertor/csdl-to-json.py
@@ -1372,6 +1372,8 @@ def main():
         config_data["Location"] = CONFIG_DEF_LOCATION
     if "ResourceLocation" not in config_data:
         config_data["ResourceLocation"] = CONFIG_DEF_RESOURCE_LOCATION
+    if "DoNotWrite" not in config_data:
+        config_data["DoNotWrite"] = []
 
     # Get the definition for Resource
     resource_file = args.input + os.path.sep + "Resource_v1.xml"
@@ -1428,13 +1430,15 @@ def main():
                 translator.process()
                 for namespace in translator.json_out:
                     out_filename = args.output + os.path.sep + namespace + ".json"
+                    out_filename_short = namespace + ".json"
                     if translator.errors[namespace]:
                         print( "-- Errors detected while generating {}; not creating file".format( out_filename ) )
                     else:
-                        if overwrite or is_namespace_unversioned( namespace ) or ( not os.path.isfile( out_filename ) ):
-                            out_string = json.dumps( translator.json_out[namespace], sort_keys = True, indent = 4, separators = ( ",", ": " ) )
-                            with open( out_filename, "w" ) as file:
-                                file.write( out_string )
+                        if len( [ i for i in config_data["DoNotWrite"] if i in out_filename_short ] ) == 0:
+                            if overwrite or is_namespace_unversioned( namespace ) or ( not os.path.isfile( out_filename ) ):
+                                out_string = json.dumps( translator.json_out[namespace], sort_keys = True, indent = 4, separators = ( ",", ": " ) )
+                                with open( out_filename, "w" ) as file:
+                                    file.write( out_string )
 
 def is_namespace_unversioned( namespace ):
     """

--- a/csdl-to-json-convertor/dmtf-config.json
+++ b/csdl-to-json-convertor/dmtf-config.json
@@ -3,5 +3,6 @@
     "RedfishSchema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
     "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata-v4.json",
     "Location": "http://redfish.dmtf.org/schemas/v1/",
-    "ResourceLocation": "http://redfish.dmtf.org/schemas/v1/"
+    "ResourceLocation": "http://redfish.dmtf.org/schemas/v1/",
+    "DoNotWrite": [ "Volume.", "VolumeCollection.", "RedfishError.", "RedfishExtensions.", "Validation." ]
 }

--- a/json-to-openapi-converter/README.md
+++ b/json-to-openapi-converter/README.md
@@ -50,6 +50,7 @@ The config file is a JSON file that contains five properties at the root of the 
 * TaskRef: A pointer to the JSON Schema definition of Task
 * MessageRef: A pointer to the JSON Schema definition of Message
 * ODataSchema: A pointer to the OData extensions to JSON Schema
+* DoNotWrite: A list of the output files to filter out when writing the YAML files
 * Extensions: A structure containing additional URIs to apply to a given resource type if provided in the base OpenAPI Service Document
 
 Sample File:
@@ -69,6 +70,11 @@ Sample File:
     "TaskRef": "http://redfish.dmtf.org/schemas/v1/Task.v1_3_0.yaml#/components/schemas/Task",
     "MessageRef": "http://redfish.dmtf.org/schemas/v1/Message.v1_0_6.yaml#/components/schemas/Message",
     "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.yaml",
+    "DoNotWrite": [
+        "redfish-error.",
+        "redfish-payload-annotations.",
+        "redfish-schema.",
+        "redfish-schema-" ],
     "Extensions": {
         "Drive": [
             "/redfish/v1/SpecialDriveArray/{DriveId}"

--- a/json-to-openapi-converter/dmtf-config.json
+++ b/json-to-openapi-converter/dmtf-config.json
@@ -3,7 +3,7 @@
         "title": "Redfish",
         "x-copyright": "Copyright 2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
         "description": "This contains the definition of a Redfish service.",
-        "version": "2019.2",
+        "version": "2019.3",
         "contact": {
             "name": "DMTF",
             "url": "https://www.dmtf.org/standards/redfish"
@@ -12,5 +12,6 @@
     "OutputFile": "openapi.yaml",
     "TaskRef": "http://redfish.dmtf.org/schemas/v1/Task.v1_4_2.yaml#/components/schemas/Task",
     "MessageRef": "http://redfish.dmtf.org/schemas/v1/Message.v1_0_8.yaml#/components/schemas/Message",
-    "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata-v4.yaml"
+    "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata-v4.yaml",
+    "DoNotWrite": [ "Volume.", "VolumeCollection.", "redfish-error.", "redfish-payload-annotations.", "redfish-schema.", "redfish-schema-" ]
 }

--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -60,9 +60,10 @@ class JSONToYAML:
         task_ref: The location for the Task schema file
         info_block: The info block to put in the OpenAPI Service Document
         extensions: The URI extensions to apply to given resource types
+        do_not_write: A list of files to not write
     """
 
-    def __init__( self, input, output, overwrite, base_file, service_file, odata_schema, message_ref, task_ref, info_block, extensions ):
+    def __init__( self, input, output, overwrite, base_file, service_file, odata_schema, message_ref, task_ref, info_block, extensions, do_not_write ):
         self.odata_schema = odata_schema
         self.message_ref = message_ref
         self.task_ref = task_ref
@@ -113,10 +114,12 @@ class JSONToYAML:
                     self.update_object( json_data )
 
                     out_filename = output + os.path.sep + filename.rsplit( ".", 1 )[0] + ".yaml"
-                    if overwrite or is_unversioned( filename ) or ( not os.path.isfile( out_filename ) ):
-                        out_string = yaml.dump( json_data, default_flow_style = False )
-                        with open( out_filename, "w" ) as file:
-                            file.write( out_string )
+                    out_filename_short = filename.rsplit( ".", 1 )[0] + ".yaml"
+                    if len( [ i for i in do_not_write if i in out_filename_short ] ) == 0:
+                        if overwrite or is_unversioned( filename ) or ( not os.path.isfile( out_filename ) ):
+                            out_string = yaml.dump( json_data, default_flow_style = False )
+                            with open( out_filename, "w" ) as file:
+                                file.write( out_string )
 
         # Update the URI information with the action information collected
         self.update_uri_info_with_actions()
@@ -754,11 +757,13 @@ if __name__ == '__main__':
         config_data["TaskRef"] = CONFIG_DEF_TASK_REF
     if "Extensions" not in config_data:
         config_data["Extensions"] = CONFIG_DEF_EXTENSIONS
+    if "DoNotWrite" not in config_data:
+        config_data["DoNotWrite"] = []
     if "info" not in config_data:
         print( "ERROR: Configuration file does not contain 'info' data" )
         sys.exit( 1 )
 
     # Funnel everything to the translator
-    JSONToYAML( args.input, args.output, overwrite, args.base, config_data["OutputFile"], config_data["ODataSchema"], config_data["MessageRef"], config_data["TaskRef"], config_data["info"], config_data["Extensions"] )
+    JSONToYAML( args.input, args.output, overwrite, args.base, config_data["OutputFile"], config_data["ODataSchema"], config_data["MessageRef"], config_data["TaskRef"], config_data["info"], config_data["Extensions"], config_data["DoNotWrite"] )
 
     sys.exit( 0 )

--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -115,7 +115,7 @@ class JSONToYAML:
 
                     out_filename = output + os.path.sep + filename.rsplit( ".", 1 )[0] + ".yaml"
                     out_filename_short = filename.rsplit( ".", 1 )[0] + ".yaml"
-                    if len( [ i for i in do_not_write if i in out_filename_short ] ) == 0:
+                    if len( [ i for i in do_not_write if out_filename_short.startswith( i ) ] ) == 0:
                         if overwrite or is_unversioned( filename ) or ( not os.path.isfile( out_filename ) ):
                             out_string = yaml.dump( json_data, default_flow_style = False )
                             with open( out_filename, "w" ) as file:

--- a/redfish-repo-test/csdl-syntax-test.js
+++ b/redfish-repo-test/csdl-syntax-test.js
@@ -52,9 +52,12 @@ const NonPascalCaseEnumWhiteList = ['iSCSI', 'iQN', 'FC_WWN', 'TX_RX', 'EIA_310'
 const NonPascalCasePropertyWhiteList = ['iSCSIBoot'];
 
 const ODataSchemaFileList = [ 'Org.OData.Core.V1.xml', 'Org.OData.Capabilities.V1.xml', 'Org.OData.Measures.V1.xml' ];
-const SwordfishSchemaFileList = [ 'ConsistencyGroupCollection_v1.xml', 'EndpointGroupCollection_v1.xml', 'FileSystemCollection_v1.xml', 'HostedStorageServices_v1.xml',
-                                  'StorageGroupCollection_v1.xml', 'StoragePool_v1.xml', 'StoragePoolCollection_v1.xml', 'StorageServiceCollection_v1.xml',
-                                  'StorageSystemCollection_v1.xml', 'StorageService_v1.xml', 'Volume_v1.xml', 'VolumeCollection_v1.xml' ];
+const SwordfishSchemaFileList = [ 'Capacity_v1.xml', 'ClassOfService_v1.xml', 'ConsistencyGroup_v1.xml', 'ConsistencyGroupCollection_v1.xml',
+                                  'DataStorageLoSCapabilities_v1.xml', 'EndpointGroupCollection_v1.xml', 'FileSystemCollection_v1.xml',
+                                  'HostedStorageServices_v1.xml', 'IOStatistics_v1.xml', 'SpareResourceSet_v1.xml', 'StorageGroup_v1.xml',
+                                  'StorageGroupCollection_v1.xml', 'StoragePool_v1.xml', 'StoragePoolCollection_v1.xml', 'StorageReplicaInfo_v1.xml',
+                                  'StorageServiceCollection_v1.xml', 'StorageSystemCollection_v1.xml', 'StorageService_v1.xml', 'Volume_v1.xml',
+                                  'VolumeCollection_v1.xml' ];
 const ContosoSchemaFileList = [ 'ContosoExtensions_v1.xml', 'TurboencabulatorService_v1.xml' ];
 const EntityTypesWithNoActions = [ 'ServiceRoot', 'ItemOrCollection', 'Item', 'ReferenceableMember', 'Resource', 'ResourceCollection', 'ActionInfo', 'TurboencabulatorService' ];
 const OldRegistries = ['Base.1.0.0.json', 'ResourceEvent.1.0.0.json', 'TaskEvent.1.0.0.json', 'Redfish_1.0.1_PrivilegeRegistry.json', 'Redfish_1.0.2_PrivilegeRegistry.json'];

--- a/redfish-repo-test/openapi-test.js
+++ b/redfish-repo-test/openapi-test.js
@@ -29,7 +29,7 @@ describe('OpenAPI/YAML', () => {
       if(file.includes('openapi.yaml')) {
         it('Is Valid OpenAPI', function() { 
           this.retries(2); //Retry in case of HTTP errors
-          this.timeout(30000);
+          this.timeout(60000);
           let doc = yaml.safeLoad(txt);
           return SwaggerParser.validate(doc, {resolve: {custom: customOpenAPIResolver}});
         });

--- a/redfish-repo-test/package.json
+++ b/redfish-repo-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redfishrepotest",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A set of tests for Redfish Mockups, CSDL, OpenAPI, and JSON Schemas.",
   "main": "index.js",
   "scripts": {

--- a/redfish-repo-test/package.json
+++ b/redfish-repo-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redfishrepotest",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "A set of tests for Redfish Mockups, CSDL, OpenAPI, and JSON Schemas.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix #260; added a DoNotWrite option in the config files for the converter tools so the output doesn't need to be manually pruned.

More Swordfish files being whitelisted.

Bumped the OpenAPI validation timeout.