### PR TITLE
Skip new tests on external schemas

### DIFF
--- a/redfish-repo-test/csdl-syntax-test.js
+++ b/redfish-repo-test/csdl-syntax-test.js
@@ -26,6 +26,11 @@ if(config.has('Redfish.AdditionalSchemaDirs')) {
 //Setup a global cache for speed
 options.cache = new CSDL.cache(options.useLocal, options.useNetwork);
 
+var skipCheckSchemaList = [];
+if(config.has('Redfish.ExternalOwnedSchemas')) {
+  skipCheckSchemaList = config.get('Redfish.ExternalOwnedSchemas');
+}
+
 /***************** White lists ******************************/
 //Units that don't exist in UCUM
 const unitsWhiteList = ['RPM', 'V.A'];
@@ -121,7 +126,9 @@ describe('CSDL Tests', () => {
         it('Complex Types Should Not Have Permissions', () => {complexTypesPermissions(csdl);});
       }
       it('Descriptions have trailing periods', () => {if (!isYang) descriptionPeriodCheck(csdl);});
-      it('Long Descriptions do not contain may', () => {if (!isYang) descriptionMayCheck(csdl);});
+      if(skipCheckSchemaList.indexOf(fileName) === -1) {
+        it('Long Descriptions do not contain may', () => {if (!isYang) descriptionMayCheck(csdl);});
+      }
       it('No Empty Schema Tags', () => {checkForEmptySchemas(csdl);});
       it('No plural Schemas', () => {noPluralSchemas(csdl);});
       it('BaseTypes are valid', () => {checkBaseTypes(csdl);});

--- a/redfish-repo-test/csdl-syntax-test.js
+++ b/redfish-repo-test/csdl-syntax-test.js
@@ -116,6 +116,9 @@ describe('CSDL Tests', () => {
       it('Valid Syntax', () => {
         assert.notEqual(csdl, null);
       });
+      if(skipCheckSchemaList.indexOf(fileName) !== -1) {
+        return;
+      }
       //These tests are only valid for new format CSDL...
       if(file.indexOf('_v') !== -1) {
         it('Units are valid', () => {validUnitsTest(csdl);});
@@ -126,9 +129,7 @@ describe('CSDL Tests', () => {
         it('Complex Types Should Not Have Permissions', () => {complexTypesPermissions(csdl);});
       }
       it('Descriptions have trailing periods', () => {if (!isYang) descriptionPeriodCheck(csdl);});
-      if(skipCheckSchemaList.indexOf(fileName) === -1) {
-        it('Long Descriptions do not contain may', () => {if (!isYang) descriptionMayCheck(csdl);});
-      }
+      it('Long Descriptions do not contain may', () => {if (!isYang) descriptionMayCheck(csdl);});
       it('No Empty Schema Tags', () => {checkForEmptySchemas(csdl);});
       it('No plural Schemas', () => {noPluralSchemas(csdl);});
       it('BaseTypes are valid', () => {checkBaseTypes(csdl);});


### PR DESCRIPTION
The Swordfish schemas still have mays in them. Would like to have them fix that though. This change allows DMTF repo to ignore Swordfish schema with a config change. 