### PR TITLE
OpenAPI Rename Types

### DIFF
--- a/json-to-openapi-converter/dmtf-config.json
+++ b/json-to-openapi-converter/dmtf-config.json
@@ -10,8 +10,8 @@
         }
     },
     "OutputFile": "openapi.yaml",
-    "TaskRef": "http://redfish.dmtf.org/schemas/v1/Task.v1_4_3.yaml#/components/schemas/Task",
-    "MessageRef": "http://redfish.dmtf.org/schemas/v1/Message.v1_1_0.yaml#/components/schemas/Message",
+    "TaskRef": "http://redfish.dmtf.org/schemas/v1/Task.v1_4_3.yaml#/components/schemas/Task.v1_4_3.Task",
+    "MessageRef": "http://redfish.dmtf.org/schemas/v1/Message.v1_1_0.yaml#/components/schemas/Message.v1_1_0.Message",
     "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata-v4.yaml",
     "DoNotWrite": [ "Volume.", "VolumeCollection.", "redfish-error.", "redfish-payload-annotations.", "redfish-schema.", "redfish-schema-" ]
 }


### PR DESCRIPTION
Most of the OpenAPI tooling flattens the entire definition list. It seems that they rely on a recommendation from JSON Schema where names of definitions should be unique. Some of our resources have structure names that are reused (Links for example), and the resources themselves will collide simply because of our versioning methodology. This change prepends all type definitions with the schema file name and version string to ensure uniqueness everywhere.