### PR TITLE
Removed some config file settings that should no longer be overridden

### DIFF
--- a/csdl-to-json-convertor/README.md
+++ b/csdl-to-json-convertor/README.md
@@ -41,20 +41,14 @@ optional arguments:
 
 The config file can contain up to five parameters; parameters not defined will have a default value in the tool:
 * Copyright: The copyright string to include in the JSON Schema files
-* RedfishSchema: A pointer to the Redfish extensions to JSON Schema
-* ODataSchema: A pointer to the OData extensions to JSON Schema
 * Location: A pointer to the web folder where the resulting JSON Schema files will be published
-* ResourceLocation: A pointer to the web folder where the core Resource_v1.xml file can be found
 * DoNotWrite: A list of the output files to filter out when writing the JSON files
 
 Sample File and Default Values:
 ```
 {
     "Copyright": "Copyright 2014-2017 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
-    "RedfishSchema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_2_0.json",
-    "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata.4.0.0.json",
     "Location": "http://redfish.dmtf.org/schemas/v1/",
-    "ResourceLocation": "http://redfish.dmtf.org/schemas/v1/",
     "DoNotWrite": []
 }
 ```

--- a/csdl-to-json-convertor/csdl-to-json.py
+++ b/csdl-to-json-convertor/csdl-to-json.py
@@ -1435,14 +1435,11 @@ def main():
     # Set up defaults for missing configuration fields
     if "Copyright" not in config_data:
         config_data["Copyright"] = CONFIG_DEF_COPYRIGHT
-    if "RedfishSchema" not in config_data:
-        config_data["RedfishSchema"] = CONFIG_DEF_REDFISH_SCHEMA
-    if "ODataSchema" not in config_data:
-        config_data["ODataSchema"] = CONFIG_DEF_ODATA_SCHEMA
+    config_data["RedfishSchema"] = CONFIG_DEF_REDFISH_SCHEMA
+    config_data["ODataSchema"] = CONFIG_DEF_ODATA_SCHEMA
     if "Location" not in config_data:
         config_data["Location"] = CONFIG_DEF_LOCATION
-    if "ResourceLocation" not in config_data:
-        config_data["ResourceLocation"] = CONFIG_DEF_RESOURCE_LOCATION
+    config_data["ResourceLocation"] = CONFIG_DEF_RESOURCE_LOCATION
     if "DoNotWrite" not in config_data:
         config_data["DoNotWrite"] = []
 

--- a/json-to-openapi-converter/README.md
+++ b/json-to-openapi-converter/README.md
@@ -49,7 +49,6 @@ The config file is a JSON file that contains five properties at the root of the 
 * OutputFile: The name of the output file for the OpenAPI Service Document
 * TaskRef: A pointer to the JSON Schema definition of Task
 * MessageRef: A pointer to the JSON Schema definition of Message
-* ODataSchema: A pointer to the OData extensions to JSON Schema
 * DoNotWrite: A list of the output files to filter out when writing the YAML files
 * Extensions: A structure containing additional URIs to apply to a given resource type if provided in the base OpenAPI Service Document
 
@@ -69,7 +68,6 @@ Sample File:
     "OutputFile": "openapi.yaml",
     "TaskRef": "http://redfish.dmtf.org/schemas/v1/Task.v1_3_0.yaml#/components/schemas/Task",
     "MessageRef": "http://redfish.dmtf.org/schemas/v1/Message.v1_0_6.yaml#/components/schemas/Message",
-    "ODataSchema": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.yaml",
     "DoNotWrite": [
         "redfish-error.",
         "redfish-payload-annotations.",

--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -795,8 +795,7 @@ if __name__ == '__main__':
     # Manage the configuration data
     if "OutputFile" not in config_data:
         config_data["OutputFile"] = CONFIG_DEF_OUT_FILE
-    if "ODataSchema" not in config_data:
-        config_data["ODataSchema"] = CONFIG_DEF_ODATA_SCHEMA_LOC
+    config_data["ODataSchema"] = CONFIG_DEF_ODATA_SCHEMA_LOC
     if "MessageRef" not in config_data:
         config_data["MessageRef"] = CONFIG_DEF_MESSAGE_REF
     if "TaskRef" not in config_data:


### PR DESCRIPTION
Core definitions like Resource, OData definitions, and Redfish JSON Schema extensions all have hardened URIs for their latest versions. It's not longer needed to have this specified as a config file argument, which could result in older config files referencing stale documents.