### PR TITLE
Removed description combination

### DIFF
--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -1662,8 +1662,6 @@ class DocFormatter:
                         descr = descr + ' ' + combined_prop_item['longDescription']
                         combined_prop_item['longDescription'] = descr
                     else:
-                        if prop_items[0].get('description'):
-                            descr = descr + ' ' + combined_prop_item['description']
                         combined_prop_item['description'] = descr
                     if fulldescription_override:
                         combined_prop_item['fulldescription_override'] = fulldescription_override

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -1658,8 +1658,7 @@ class DocFormatter:
                     combined_prop_item['enumVersionAdded'] = prop_info.get('enumVersionAdded')
                     combined_prop_item['enumVersionDeprecated'] = prop_info.get('enumVersionDeprecated')
                     combined_prop_item['enumDeprecated'] = prop_info.get('enumDeprecated')
-                    if self.config.get('normative') and combined_prop_item.get('longDescription'):
-                        descr = descr + ' ' + combined_prop_item['longDescription']
+                    if self.config.get('normative'):
                         combined_prop_item['longDescription'] = descr
                     else:
                         combined_prop_item['description'] = descr


### PR DESCRIPTION
Removed the combination of property and enum type descriptions which was used when collapsing array properties into a single line.  The combination may have been necessary in early schema where descriptions were not fully populated, but this now creates duplicate text.