### PR TITLE
Doc generator updates: excerpt links and heading levels

### DIFF
--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -932,7 +932,7 @@ class DocFormatter:
                                                              % {'link': excerpt_link})
 
                     elif self.config.get('combine_multiple_refs') and self.ref_counts.get(schema_ref, {}).get(requested_ref_uri, 0) >= self.config['combine_multiple_refs']:
-                        anchor = schema_ref + '|details_combined_ref|' + prop_name
+                        anchor = schema_ref + '|details|' + prop_name
                         ref_info['add_link_text'] = (_('For more information about this property, see %(link)s in Property Details.')
                                                          % {'link': self.link_to_anchor(prop_name, anchor)})
                         ref_info['_ref_description'] = ref_info['description']

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -644,9 +644,9 @@ class MarkdownGenerator(DocFormatter):
                 caption = self.formatter.add_table_caption(section["head"] + " properties")
                 preamble = self.formatter.add_table_reference("The properties defined for the " + section["head"] + " schema are summarized in ")
 
-                # properites are a peer of URIs, if they exist
+                # properties are a peer of URIs, if they exist
                 # TODO: this should use make_table()
-                contents.append('\n' + self.formatter.head_two('Properties', self.level))
+                contents.append('\n' + self.format_head_three('Properties', self.level))
                 contents.append(preamble + "\n")
                 contents.append('|Property     |Type     |Notes     |')
 
@@ -819,7 +819,7 @@ search: true
 
     def add_description(self, text):
         """ Add the schema description """
-        self.this_section['description'] = "## " + _('Description') + "\n\n" + text + '\n'
+        self.this_section['description'] = self.format_head_three(_('Description'), self.level) + self.formatter.para(text)
 
 
     def add_deprecation_text(self, deprecation_text):
@@ -830,7 +830,7 @@ search: true
 
     def add_uris(self, uris):
         """ Add the URIs (which should be a list) """
-        uri_block = "## " + _('URIs') + "\n"
+        uri_block = self.format_head_three(_('URIs'), self.level)
         for uri in sorted(uris, key=str.lower):
             uri_block += "\n" + self.format_uri(uri)
         self.this_section['uris'] = uri_block + "\n"

--- a/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_output.md
@@ -15,12 +15,12 @@ The revision history is summarized in [Table TBL_nn++](#table_TBL_nn "Revision h
 | **Release** | 2018.2 |
 
 Table: Table TBL_nn: <a name=table_TBL_nn>Revision history</a>
-## Description
+### Description
 
 A Network Device Function represents a logical interface exposed by the network adapter.
 
 
-## Properties
+### Properties
 
 The properties defined for the NetworkDeviceFunction 1.3.2 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunction 1.3.2 properties").
 
@@ -179,7 +179,7 @@ Table: Table TBL_nn: <a name=table_TBL_nn>WWNSource property values</a>
 ## NetworkDeviceFunctionCollection
 
 
-## Properties
+### Properties
 
 The properties defined for the NetworkDeviceFunctionCollection schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunctionCollection properties").
 
@@ -197,12 +197,12 @@ Table: Table TBL_nn: <a name=table_TBL_nn>NetworkDeviceFunctionCollection proper
 
 ## NetworkPort 1.1.0
 
-## Description
+### Description
 
 A Network Port represents a discrete physical port capable of connecting to a network.
 
 
-## Properties
+### Properties
 
 The properties defined for the NetworkPort 1.1.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkPort 1.1.0 properties").
 

--- a/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/markdown_output.md
@@ -7,12 +7,12 @@ search: true
 
 ## IntegerTest 1.0.0
 
-## Description
+### Description
 
 This schema contains one or more properties of type integer.
 
 
-## Properties
+### Properties
 
 The properties defined for the IntegerTest 1.0.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "IntegerTest 1.0.0 properties").
 

--- a/doc-generator/tests/samples/generate_docs_cases/required/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/required/expected_output/markdown_output.md
@@ -7,12 +7,12 @@ search: true
 
 ## RequiredTest 1.0.0
 
-## Description
+### Description
 
 This schema contains required and requiredOnCreate properties.
 
 
-## Properties
+### Properties
 
 The properties defined for the RequiredTest 1.0.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "RequiredTest 1.0.0 properties").
 


### PR DESCRIPTION
Two unrelated corrections: 
* Improve the links produced for excerpts that are moved into the Property Details section (due to combining of multiple references)
* Correct the heading levels of some recently-added headings in the markdown format. 