### PR TITLE
Make "numbered" table headings optional. Fixes #335

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
  - "3.6"
  - "3.7"
  - "3.8"
- - "3.9-dev"
+ - "3.9"
 install: true
 env:
  - TEST_DIR=doc-generator

--- a/doc-generator/Pipfile
+++ b/doc-generator/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [requires]
-python_version = "3.7"
+python_version = "3"
 
 [dev-packages]
 pytest = "*"

--- a/doc-generator/README_config_files.md
+++ b/doc-generator/README_config_files.md
@@ -43,6 +43,7 @@ Note that the names of some config keys differ from their command-line counterpa
 - registry_uri_to_local: For profile mode only, an object like uri_mapping, for locations of registries.
 - subset (command_line: `subset`): Path to a JSON profile document. Generates "Schema subset" output, with the subset defined in the JSON profile document.
 - uri_mapping: this should be an object with the partial URL of schema repositories as attributes, and local directory paths as values.
+- with_table_numbering: Boolean, default false. Applies to markdown output only! When true, table captions and references will be added to the output. You will need to run a post-processor on the output to complete the numbering. See TABLE_NUMBER_README.md[TABLE_NUMBER_README.md].
 
 
 ### In More Detail

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -199,9 +199,11 @@ class DocFormatter:
             versions.append(self.formatter.italic(elt['version']))
             releases.append(elt['release'])
         heading = self.formatter.head_three(_("Revision history"), self.level);
-        caption = self.formatter.add_table_caption(_("Revision history"));
-        reference = self.formatter.add_table_reference(_("The revision history is summarized in "));
-        formatted = reference + "\n\n" + self.formatter.make_table([self.formatter.make_row(versions), self.formatter.make_row(releases)]) + "\n\n" +caption
+        formatted = self.formatter.make_table([self.formatter.make_row(versions), self.formatter.make_row(releases)])
+        if self.config.get('with_table_numbering'):
+            caption = self.formatter.add_table_caption(_("Revision history"));
+            reference = self.formatter.add_table_reference(_("The revision history is summarized in "));
+            formatted = reference + "\n\n" + formatted + "\n\n" +caption
         self.this_section['release_history'] = formatted
 
 

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -203,7 +203,7 @@ class DocFormatter:
         if self.config.get('with_table_numbering'):
             caption = self.formatter.add_table_caption(_("Revision history"));
             reference = self.formatter.add_table_reference(_("The revision history is summarized in "));
-            formatted = reference + "\n\n" + formatted + "\n\n" +caption
+            formatted = reference + "\n\n" + formatted + "\n\n" + caption
         self.this_section['release_history'] = formatted
 
 

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -327,7 +327,8 @@ class MarkdownGenerator(DocFormatter):
                     enum = [x for x in enum if x in profile_parameter_values]
 
         if prop_description:
-            contents.append(self.formatter.para(self.escape_for_markdown(prop_description, self.config.get('escape_chars', []))))
+            contents.append(self.escape_for_markdown(prop_description, self.config.get('escape_chars', [])))
+            contents.append('') # for a newline after. (self.formatter.para would also add one before, excessively)
 
         if isinstance(prop_type, list):
             prop_type = ', '.join(prop_type)
@@ -480,7 +481,7 @@ class MarkdownGenerator(DocFormatter):
         if self.config.get('with_table_numbering'):
             caption = self.formatter.add_table_caption(_("%(prop_name)s property values") % {'prop_name': prop_name})
             preamble = self.formatter.add_table_reference(_("The defined property values are listed in "))
-            formatted = preamble + formatted + caption
+            formatted = preamble + '\n' + formatted + caption
 
         return formatted
 
@@ -646,6 +647,7 @@ class MarkdownGenerator(DocFormatter):
 
             # something is awry if there are no properties, but ...
             if section.get('properties'):
+
                 if self.config.get('with_table_numbering'):
                     caption = self.formatter.add_table_caption(section["head"] + " properties")
                     preamble = self.formatter.add_table_reference("The properties defined for the " + section["head"] + " schema are summarized in ") + "\n"
@@ -655,12 +657,16 @@ class MarkdownGenerator(DocFormatter):
                 # properties are a peer of URIs, if they exist
                 # TODO: this should use make_table()
                 contents.append('\n' + self.format_head_three(_('Properties'), self.level))
-                contents.append(preamble)
+
+                if preamble:
+                    contents.append(preamble)
                 contents.append('|Property     |Type     |Notes     |')
 
                 contents.append('| --- | --- | --- |')
                 contents.append('\n'.join(section['properties']))
-                contents.append(caption + '\n')
+
+                if caption:
+                    contents.append(caption + '\n')
 
             if section.get('profile_conditional_details'):
                 # sort them now; these can be sub-properties so may not be in alpha order.

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -476,11 +476,13 @@ class MarkdownGenerator(DocFormatter):
                 else:
                     contents.append('| ' + enum_name + ' | ')
 
-        caption = self.formatter.add_table_caption(_("%(prop_name)s property values") % {'prop_name': prop_name})
-        preamble = self.formatter.add_table_reference(_("The defined property values are listed in "))
+        formatted = '\n'.join(contents) + '\n'
+        if self.config.get('with_table_numbering'):
+            caption = self.formatter.add_table_caption(_("%(prop_name)s property values") % {'prop_name': prop_name})
+            preamble = self.formatter.add_table_reference(_("The defined property values are listed in "))
+            formatted = preamble + formatted + caption
 
-        return preamble + '\n'.join(contents) + '\n' + caption
-
+        return formatted
 
 
     def format_action_details(self, prop_name, action_details):
@@ -555,9 +557,12 @@ class MarkdownGenerator(DocFormatter):
                 formatted_parameters = self.format_property_row(schema_ref, param_name, action_parameters[param_name], ['Actions', prop_name], False, True)
                 rows.append(formatted_parameters.get('row'))
 
-            caption = self.formatter.add_table_caption(_("%(prop_name)s action parameters") % {'prop_name': prop_name})
-            preamble = "\n" + heading + "\n\n" +  self.formatter.add_table_reference(_("The parameters for the action which are included in the POST body to the URI shown in the 'target' property of the Action are summarized in "))
-            formatted.append(preamble + "\n\n" + '\n'.join(rows) + "\n\n" + caption)
+            formatted_rows = '\n'.join(rows) + "\n"
+            if self.config.get('with_table_numbering'):
+                caption = self.formatter.add_table_caption(_("%(prop_name)s action parameters") % {'prop_name': prop_name})
+                preamble = "\n" + heading + "\n\n" +  self.formatter.add_table_reference(_("The parameters for the action which are included in the POST body to the URI shown in the 'target' property of the Action are summarized in ")) + "\n"
+                formatted_rows = preamble +  formatted_rows + caption
+            formatted.append(formatted_rows)
 
         else:
             formatted.append(self.formatter.para(heading))
@@ -641,13 +646,16 @@ class MarkdownGenerator(DocFormatter):
 
             # something is awry if there are no properties, but ...
             if section.get('properties'):
-                caption = self.formatter.add_table_caption(section["head"] + " properties")
-                preamble = self.formatter.add_table_reference("The properties defined for the " + section["head"] + " schema are summarized in ")
+                if self.config.get('with_table_numbering'):
+                    caption = self.formatter.add_table_caption(section["head"] + " properties")
+                    preamble = self.formatter.add_table_reference("The properties defined for the " + section["head"] + " schema are summarized in ") + "\n"
+                else:
+                    caption = preamble = ''
 
                 # properties are a peer of URIs, if they exist
                 # TODO: this should use make_table()
                 contents.append('\n' + self.format_head_three(_('Properties'), self.level))
-                contents.append(preamble + "\n")
+                contents.append(preamble)
                 contents.append('|Property     |Type     |Notes     |')
 
                 contents.append('| --- | --- | --- |')
@@ -670,6 +678,7 @@ class MarkdownGenerator(DocFormatter):
                 for detail_name in detail_names:
                     contents.append(self.format_head_four(detail_name + ':', 0))
                     det_info = section['property_details'][detail_name]
+
                     if len(det_info) == 1:
                         for x in det_info.values():
                             contents.append(x['formatted_descr'])

--- a/doc-generator/doc_generator.py
+++ b/doc-generator/doc_generator.py
@@ -1188,6 +1188,7 @@ class DocGenerator:
             'registry_uri_to_local': {},
             'units_translation': {},
             'combine_multiple_refs': 0,
+            'with_table_numbering': False,
             }
 
         # combined_args is an intermediate dictionary, combining command-line and config parameters.
@@ -1267,6 +1268,10 @@ class DocGenerator:
                 combined_args[param] = default
 
         config['output_format'] = combined_args['format']
+
+        # Allow "with_table_numbering" to be True only for markdown formats.
+        if config_data.get('with_table_numbering') and config['output_format'] in ['slate', 'markdown']:
+            config['with_table_numbering'] = True
 
         if combined_args.get('property_index'):
             config['output_content'] = 'property_index'

--- a/doc-generator/tests/samples/generate_docs_cases/general/expected_output/index.html
+++ b/doc-generator/tests/samples/generate_docs_cases/general/expected_output/index.html
@@ -9,15 +9,11 @@
 </head>
 <body>
 <h2 id="NetworkDeviceFunction">NetworkDeviceFunction 1.3.2</h2>
-The revision history is summarized in [Table TBL_nn++](#table_TBL_nn "Revision history").
-
 <table>
 <tbody>
 <tr><td><b>Version</b></td><td><i>v1.3</i></td></tr>
 <tr><td><b>Release</b></td><td>2018.2</td></tr>
 </tbody></table>
-
-Table: Table TBL_nn: <a name=table_TBL_nn>Revision history</a>
 <p>A Network Device Function represents a logical interface exposed by the network adapter.</p>
 <table class="properties">
 <tbody>

--- a/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_output.md
@@ -7,14 +7,10 @@ search: true
 
 ## NetworkDeviceFunction 1.3.2
 
-The revision history is summarized in [Table TBL_nn++](#table_TBL_nn "Revision history").
-
 |     |     |
 | --- | --- |
 | **Version** | *v1.3* |
 | **Release** | 2018.2 |
-
-Table: Table TBL_nn: <a name=table_TBL_nn>Revision history</a>
 ### Description
 
 A Network Device Function represents a logical interface exposed by the network adapter.
@@ -22,7 +18,7 @@ A Network Device Function represents a logical interface exposed by the network 
 
 ### Properties
 
-The properties defined for the NetworkDeviceFunction 1.3.2 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunction 1.3.2 properties").
+
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -100,14 +96,14 @@ The properties defined for the NetworkDeviceFunction 1.3.2 schema are summarized
 | } |   |   |
 | **Status** {} | object | This property describes the status and health of the resource and its children. See the *Resource* schema for details on this property. |
 | **VirtualFunctionsEnabled** | boolean<br><br>*read-only<br>(null)* | Whether Single Root I/O Virtualization (SR-IOV) Virual Functions (VFs) are enabled for this Network Device Function. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetworkDeviceFunction 1.3.2 properties</a>
+
 
 
 ### Property details
 
 #### AuthenticationMethod:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "AuthenticationMethod property values").
+
 The iSCSI boot authentication method for this network device function.
 
 | string | Description |
@@ -115,10 +111,10 @@ The iSCSI boot authentication method for this network device function.
 | CHAP | iSCSI Challenge Handshake Authentication Protocol (CHAP) authentication is used. |
 | MutualCHAP | iSCSI Mutual Challenge Handshake Authentication Protocol (CHAP) authentication is used. |
 | None | No iSCSI authentication is used. |
-Table: Table TBL_nn: <a name=table_TBL_nn>AuthenticationMethod property values</a>
+
 #### BootMode:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "BootMode property values").
+
 The boot mode configured for this network device function.
 
 | string | Description |
@@ -128,20 +124,20 @@ The boot mode configured for this network device function.
 | FibreChannelOverEthernet | Boot this device using the embedded Fibre Channel over Ethernet (FCoE) boot support and configuration.  Only applicable if the NetworkDeviceFunctionType is set to FibreChannelOverEthernet. |
 | iSCSI | Boot this device using the embedded iSCSI boot support and configuration.  Only applicable if the NetworkDeviceFunctionType is set to iSCSI. |
 | PXE | Boot this device using the embedded PXE support.  Only applicable if the NetworkDeviceFunctionType is set to Ethernet. |
-Table: Table TBL_nn: <a name=table_TBL_nn>BootMode property values</a>
+
 #### IPAddressType:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "IPAddressType property values").
+
 The type of IP address (IPv6 or IPv4) being populated in the iSCSIBoot IP address fields.
 
 | string | Description |
 | --- | --- |
 | IPv4 | IPv4 addressing is used for all IP-fields in this object. |
 | IPv6 | IPv6 addressing is used for all IP-fields in this object. |
-Table: Table TBL_nn: <a name=table_TBL_nn>IPAddressType property values</a>
+
 #### NetDevFuncCapabilities:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "NetDevFuncCapabilities property values").
+
 Capabilities of this network device function.
 
 | string | Description |
@@ -151,10 +147,10 @@ Capabilities of this network device function.
 | FibreChannel | Appears to the operating system as a Fibre Channel device. |
 | FibreChannelOverEthernet | Appears to the operating system as an FCoE device. |
 | iSCSI | Appears to the operating system as an iSCSI device. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetDevFuncCapabilities property values</a>
+
 #### NetDevFuncType:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "NetDevFuncType property values").
+
 The configured capability of this network device function.
 
 | string | Description |
@@ -164,24 +160,24 @@ The configured capability of this network device function.
 | FibreChannel | Appears to the operating system as a Fibre Channel device. |
 | FibreChannelOverEthernet | Appears to the operating system as an FCoE device. |
 | iSCSI | Appears to the operating system as an iSCSI device. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetDevFuncType property values</a>
+
 #### WWNSource:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "WWNSource property values").
+
 The configuration source of the WWNs for this connection (WWPN and WWNN).
 
 | string | Description |
 | --- | --- |
 | ConfiguredLocally | The set of FC/FCoE boot targets was applied locally through API or UI. |
 | ProvidedByFabric | The set of FC/FCoE boot targets was applied by the Fibre Channel fabric. |
-Table: Table TBL_nn: <a name=table_TBL_nn>WWNSource property values</a>
+
 
 ## NetworkDeviceFunctionCollection
 
 
 ### Properties
 
-The properties defined for the NetworkDeviceFunctionCollection schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunctionCollection properties").
+
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -192,7 +188,7 @@ The properties defined for the NetworkDeviceFunctionCollection schema are summar
 | } ] |   |   |
 | **Name** | string<br><br>*read-only* | The name of the resource or array element. |
 | **Oem** {} | object | This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections. See the *Resource* schema for details on this property. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetworkDeviceFunctionCollection properties</a>
+
 
 
 ## NetworkPort 1.1.0
@@ -204,7 +200,7 @@ A Network Port represents a discrete physical port capable of connecting to a ne
 
 ### Properties
 
-The properties defined for the NetworkPort 1.1.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkPort 1.1.0 properties").
+
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -241,14 +237,14 @@ The properties defined for the NetworkPort 1.1.0 schema are summarized in [Table
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**LinkSpeedMbps** | number<br><br>*read-only<br>(null)* | The speed of the link in Mbps when this link network technology is active. |
 | } ] |   |   |
 | **WakeOnLANEnabled** | boolean<br><br>*read-write<br>(null)* | Whether Wake on LAN (WoL) is enabled for this network port. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetworkPort 1.1.0 properties</a>
+
 
 
 ### Property details
 
 #### ActiveLinkTechnology:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "ActiveLinkTechnology property values").
+
 Network Port Active Link Technology.
 
 | string | Description |
@@ -256,10 +252,10 @@ Network Port Active Link Technology.
 | Ethernet | The port is capable of connecting to an Ethernet network. |
 | FibreChannel | The port is capable of connecting to a Fibre Channel network. |
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
-Table: Table TBL_nn: <a name=table_TBL_nn>ActiveLinkTechnology property values</a>
+
 #### FlowControlConfiguration:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "FlowControlConfiguration property values").
+
 The locally configured 802.3x flow control setting for this network port.
 
 | string | Description |
@@ -268,10 +264,10 @@ The locally configured 802.3x flow control setting for this network port.
 | RX | IEEE 802.3x flow control may be initiated by the link partner. |
 | TX | IEEE 802.3x flow control may be initiated by this station. |
 | TX_RX | IEEE 802.3x flow control may be initiated by this station or the link partner. |
-Table: Table TBL_nn: <a name=table_TBL_nn>FlowControlConfiguration property values</a>
+
 #### FlowControlStatus:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "FlowControlStatus property values").
+
 The 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only).
 
 | string | Description |
@@ -280,10 +276,10 @@ The 802.3x flow control behavior negotiated with the link partner for this netwo
 | RX | IEEE 802.3x flow control may be initiated by the link partner. |
 | TX | IEEE 802.3x flow control may be initiated by this station. |
 | TX_RX | IEEE 802.3x flow control may be initiated by this station or the link partner. |
-Table: Table TBL_nn: <a name=table_TBL_nn>FlowControlStatus property values</a>
+
 #### LinkNetworkTechnology:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "LinkNetworkTechnology property values").
+
 The self-described link network technology capabilities of this port.
 
 | string | Description |
@@ -291,24 +287,23 @@ The self-described link network technology capabilities of this port.
 | Ethernet | The port is capable of connecting to an Ethernet network. |
 | FibreChannel | The port is capable of connecting to a Fibre Channel network. |
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
-Table: Table TBL_nn: <a name=table_TBL_nn>LinkNetworkTechnology property values</a>
+
 #### LinkStatus:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "LinkStatus property values").
+
 The status of the link between this port and its link partner.
 
 | string | Description |
 | --- | --- |
 | Down | The port is enabled but link is down. |
 | Up | The port is enabled and link is good (up). |
-Table: Table TBL_nn: <a name=table_TBL_nn>LinkStatus property values</a>
+
 #### SupportedEthernetCapabilities:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "SupportedEthernetCapabilities property values").
+
 The set of Ethernet capabilities that this port supports.
 
 | string | Description |
 | --- | --- |
 | EEE | IEEE 802.3az Energy Efficient Ethernet (EEE) is supported on this port. |
 | WakeOnLAN | Wake on LAN (WoL) is supported on this port. |
-Table: Table TBL_nn: <a name=table_TBL_nn>SupportedEthernetCapabilities property values</a>

--- a/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_output.md
@@ -18,8 +18,6 @@ A Network Device Function represents a logical interface exposed by the network 
 
 ### Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **@odata.etag** | string<br><br>*read-only* | The current ETag of the resource. |
@@ -97,12 +95,9 @@ A Network Device Function represents a logical interface exposed by the network 
 | **Status** {} | object | This property describes the status and health of the resource and its children. See the *Resource* schema for details on this property. |
 | **VirtualFunctionsEnabled** | boolean<br><br>*read-only<br>(null)* | Whether Single Root I/O Virtualization (SR-IOV) Virual Functions (VFs) are enabled for this Network Device Function. |
 
-
-
 ### Property details
 
 #### AuthenticationMethod:
-
 
 The iSCSI boot authentication method for this network device function.
 
@@ -113,7 +108,6 @@ The iSCSI boot authentication method for this network device function.
 | None | No iSCSI authentication is used. |
 
 #### BootMode:
-
 
 The boot mode configured for this network device function.
 
@@ -127,7 +121,6 @@ The boot mode configured for this network device function.
 
 #### IPAddressType:
 
-
 The type of IP address (IPv6 or IPv4) being populated in the iSCSIBoot IP address fields.
 
 | string | Description |
@@ -136,7 +129,6 @@ The type of IP address (IPv6 or IPv4) being populated in the iSCSIBoot IP addres
 | IPv6 | IPv6 addressing is used for all IP-fields in this object. |
 
 #### NetDevFuncCapabilities:
-
 
 Capabilities of this network device function.
 
@@ -150,7 +142,6 @@ Capabilities of this network device function.
 
 #### NetDevFuncType:
 
-
 The configured capability of this network device function.
 
 | string | Description |
@@ -162,7 +153,6 @@ The configured capability of this network device function.
 | iSCSI | Appears to the operating system as an iSCSI device. |
 
 #### WWNSource:
-
 
 The configuration source of the WWNs for this connection (WWPN and WWNN).
 
@@ -177,8 +167,6 @@ The configuration source of the WWNs for this connection (WWPN and WWNN).
 
 ### Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **@odata.etag** | string<br><br>*read-only* | The current ETag of the resource. |
@@ -189,8 +177,6 @@ The configuration source of the WWNs for this connection (WWPN and WWNN).
 | **Name** | string<br><br>*read-only* | The name of the resource or array element. |
 | **Oem** {} | object | This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections. See the *Resource* schema for details on this property. |
 
-
-
 ## NetworkPort 1.1.0
 
 ### Description
@@ -199,8 +185,6 @@ A Network Port represents a discrete physical port capable of connecting to a ne
 
 
 ### Properties
-
-
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -238,12 +222,9 @@ A Network Port represents a discrete physical port capable of connecting to a ne
 | } ] |   |   |
 | **WakeOnLANEnabled** | boolean<br><br>*read-write<br>(null)* | Whether Wake on LAN (WoL) is enabled for this network port. |
 
-
-
 ### Property details
 
 #### ActiveLinkTechnology:
-
 
 Network Port Active Link Technology.
 
@@ -254,7 +235,6 @@ Network Port Active Link Technology.
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
 
 #### FlowControlConfiguration:
-
 
 The locally configured 802.3x flow control setting for this network port.
 
@@ -267,7 +247,6 @@ The locally configured 802.3x flow control setting for this network port.
 
 #### FlowControlStatus:
 
-
 The 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only).
 
 | string | Description |
@@ -279,7 +258,6 @@ The 802.3x flow control behavior negotiated with the link partner for this netwo
 
 #### LinkNetworkTechnology:
 
-
 The self-described link network technology capabilities of this port.
 
 | string | Description |
@@ -290,7 +268,6 @@ The self-described link network technology capabilities of this port.
 
 #### LinkStatus:
 
-
 The status of the link between this port and its link partner.
 
 | string | Description |
@@ -299,7 +276,6 @@ The status of the link between this port and its link partner.
 | Up | The port is enabled and link is good (up). |
 
 #### SupportedEthernetCapabilities:
-
 
 The set of Ethernet capabilities that this port supports.
 

--- a/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_with_table_numbering_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/general/expected_output/markdown_with_table_numbering_output.md
@@ -5,20 +5,24 @@ search: true
 ---
 
 
-# NetworkDeviceFunction 1.3.2
+## NetworkDeviceFunction 1.3.2
+
+The revision history is summarized in [Table TBL_nn++](#table_TBL_nn "Revision history").
 
 |     |     |
 | --- | --- |
 | **Version** | *v1.3* |
 | **Release** | 2018.2 |
-## Description
+
+Table: Table TBL_nn: <a name=table_TBL_nn>Revision history</a>
+### Description
 
 A Network Device Function represents a logical interface exposed by the network adapter.
 
 
-## Properties
+### Properties
 
-
+The properties defined for the NetworkDeviceFunction 1.3.2 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunction 1.3.2 properties").
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -96,14 +100,14 @@ A Network Device Function represents a logical interface exposed by the network 
 | } |   |   |
 | **Status** {} | object | This property describes the status and health of the resource and its children. See the *Resource* schema for details on this property. |
 | **VirtualFunctionsEnabled** | boolean<br><br>*read-only<br>(null)* | Whether Single Root I/O Virtualization (SR-IOV) Virual Functions (VFs) are enabled for this Network Device Function. |
+Table: Table TBL_nn: <a name=table_TBL_nn>NetworkDeviceFunction 1.3.2 properties</a>
 
 
+### Property details
 
-## Property details
+#### AuthenticationMethod:
 
-### AuthenticationMethod:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "AuthenticationMethod property values").
 The iSCSI boot authentication method for this network device function.
 
 | string | Description |
@@ -111,10 +115,10 @@ The iSCSI boot authentication method for this network device function.
 | CHAP | iSCSI Challenge Handshake Authentication Protocol (CHAP) authentication is used. |
 | MutualCHAP | iSCSI Mutual Challenge Handshake Authentication Protocol (CHAP) authentication is used. |
 | None | No iSCSI authentication is used. |
+Table: Table TBL_nn: <a name=table_TBL_nn>AuthenticationMethod property values</a>
+#### BootMode:
 
-### BootMode:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "BootMode property values").
 The boot mode configured for this network device function.
 
 | string | Description |
@@ -124,20 +128,20 @@ The boot mode configured for this network device function.
 | FibreChannelOverEthernet | Boot this device using the embedded Fibre Channel over Ethernet (FCoE) boot support and configuration.  Only applicable if the NetworkDeviceFunctionType is set to FibreChannelOverEthernet. |
 | iSCSI | Boot this device using the embedded iSCSI boot support and configuration.  Only applicable if the NetworkDeviceFunctionType is set to iSCSI. |
 | PXE | Boot this device using the embedded PXE support.  Only applicable if the NetworkDeviceFunctionType is set to Ethernet. |
+Table: Table TBL_nn: <a name=table_TBL_nn>BootMode property values</a>
+#### IPAddressType:
 
-### IPAddressType:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "IPAddressType property values").
 The type of IP address (IPv6 or IPv4) being populated in the iSCSIBoot IP address fields.
 
 | string | Description |
 | --- | --- |
 | IPv4 | IPv4 addressing is used for all IP-fields in this object. |
 | IPv6 | IPv6 addressing is used for all IP-fields in this object. |
+Table: Table TBL_nn: <a name=table_TBL_nn>IPAddressType property values</a>
+#### NetDevFuncCapabilities:
 
-### NetDevFuncCapabilities:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "NetDevFuncCapabilities property values").
 Capabilities of this network device function.
 
 | string | Description |
@@ -147,10 +151,10 @@ Capabilities of this network device function.
 | FibreChannel | Appears to the operating system as a Fibre Channel device. |
 | FibreChannelOverEthernet | Appears to the operating system as an FCoE device. |
 | iSCSI | Appears to the operating system as an iSCSI device. |
+Table: Table TBL_nn: <a name=table_TBL_nn>NetDevFuncCapabilities property values</a>
+#### NetDevFuncType:
 
-### NetDevFuncType:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "NetDevFuncType property values").
 The configured capability of this network device function.
 
 | string | Description |
@@ -160,24 +164,24 @@ The configured capability of this network device function.
 | FibreChannel | Appears to the operating system as a Fibre Channel device. |
 | FibreChannelOverEthernet | Appears to the operating system as an FCoE device. |
 | iSCSI | Appears to the operating system as an iSCSI device. |
+Table: Table TBL_nn: <a name=table_TBL_nn>NetDevFuncType property values</a>
+#### WWNSource:
 
-### WWNSource:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "WWNSource property values").
 The configuration source of the WWNs for this connection (WWPN and WWNN).
 
 | string | Description |
 | --- | --- |
 | ConfiguredLocally | The set of FC/FCoE boot targets was applied locally through API or UI. |
 | ProvidedByFabric | The set of FC/FCoE boot targets was applied by the Fibre Channel fabric. |
+Table: Table TBL_nn: <a name=table_TBL_nn>WWNSource property values</a>
+
+## NetworkDeviceFunctionCollection
 
 
-# NetworkDeviceFunctionCollection
+### Properties
 
-
-## Properties
-
-
+The properties defined for the NetworkDeviceFunctionCollection schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunctionCollection properties").
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -188,19 +192,19 @@ The configuration source of the WWNs for this connection (WWPN and WWNN).
 | } ] |   |   |
 | **Name** | string<br><br>*read-only* | The name of the resource or array element. |
 | **Oem** {} | object | This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections. See the *Resource* schema for details on this property. |
+Table: Table TBL_nn: <a name=table_TBL_nn>NetworkDeviceFunctionCollection properties</a>
 
 
+## NetworkPort 1.1.0
 
-# NetworkPort 1.1.0
-
-## Description
+### Description
 
 A Network Port represents a discrete physical port capable of connecting to a network.
 
 
-## Properties
+### Properties
 
-
+The properties defined for the NetworkPort 1.1.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkPort 1.1.0 properties").
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -237,14 +241,14 @@ A Network Port represents a discrete physical port capable of connecting to a ne
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**LinkSpeedMbps** | number<br><br>*read-only<br>(null)* | The speed of the link in Mbps when this link network technology is active. |
 | } ] |   |   |
 | **WakeOnLANEnabled** | boolean<br><br>*read-write<br>(null)* | Whether Wake on LAN (WoL) is enabled for this network port. |
+Table: Table TBL_nn: <a name=table_TBL_nn>NetworkPort 1.1.0 properties</a>
 
 
+### Property details
 
-## Property details
+#### ActiveLinkTechnology:
 
-### ActiveLinkTechnology:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "ActiveLinkTechnology property values").
 Network Port Active Link Technology.
 
 | string | Description |
@@ -252,10 +256,10 @@ Network Port Active Link Technology.
 | Ethernet | The port is capable of connecting to an Ethernet network. |
 | FibreChannel | The port is capable of connecting to a Fibre Channel network. |
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
+Table: Table TBL_nn: <a name=table_TBL_nn>ActiveLinkTechnology property values</a>
+#### FlowControlConfiguration:
 
-### FlowControlConfiguration:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "FlowControlConfiguration property values").
 The locally configured 802.3x flow control setting for this network port.
 
 | string | Description |
@@ -264,10 +268,10 @@ The locally configured 802.3x flow control setting for this network port.
 | RX | IEEE 802.3x flow control may be initiated by the link partner. |
 | TX | IEEE 802.3x flow control may be initiated by this station. |
 | TX_RX | IEEE 802.3x flow control may be initiated by this station or the link partner. |
+Table: Table TBL_nn: <a name=table_TBL_nn>FlowControlConfiguration property values</a>
+#### FlowControlStatus:
 
-### FlowControlStatus:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "FlowControlStatus property values").
 The 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only).
 
 | string | Description |
@@ -276,10 +280,10 @@ The 802.3x flow control behavior negotiated with the link partner for this netwo
 | RX | IEEE 802.3x flow control may be initiated by the link partner. |
 | TX | IEEE 802.3x flow control may be initiated by this station. |
 | TX_RX | IEEE 802.3x flow control may be initiated by this station or the link partner. |
+Table: Table TBL_nn: <a name=table_TBL_nn>FlowControlStatus property values</a>
+#### LinkNetworkTechnology:
 
-### LinkNetworkTechnology:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "LinkNetworkTechnology property values").
 The self-described link network technology capabilities of this port.
 
 | string | Description |
@@ -287,23 +291,24 @@ The self-described link network technology capabilities of this port.
 | Ethernet | The port is capable of connecting to an Ethernet network. |
 | FibreChannel | The port is capable of connecting to a Fibre Channel network. |
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
+Table: Table TBL_nn: <a name=table_TBL_nn>LinkNetworkTechnology property values</a>
+#### LinkStatus:
 
-### LinkStatus:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "LinkStatus property values").
 The status of the link between this port and its link partner.
 
 | string | Description |
 | --- | --- |
 | Down | The port is enabled but link is down. |
 | Up | The port is enabled and link is good (up). |
+Table: Table TBL_nn: <a name=table_TBL_nn>LinkStatus property values</a>
+#### SupportedEthernetCapabilities:
 
-### SupportedEthernetCapabilities:
-
-
+The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "SupportedEthernetCapabilities property values").
 The set of Ethernet capabilities that this port supports.
 
 | string | Description |
 | --- | --- |
 | EEE | IEEE 802.3az Energy Efficient Ethernet (EEE) is supported on this port. |
 | WakeOnLAN | Wake on LAN (WoL) is supported on this port. |
+Table: Table TBL_nn: <a name=table_TBL_nn>SupportedEthernetCapabilities property values</a>

--- a/doc-generator/tests/samples/generate_docs_cases/general/expected_output/slate_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/general/expected_output/slate_output.md
@@ -18,8 +18,6 @@ A Network Device Function represents a logical interface exposed by the network 
 
 ## Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **@odata.etag** | string<br><br>*read-only* | The current ETag of the resource. |
@@ -97,12 +95,9 @@ A Network Device Function represents a logical interface exposed by the network 
 | **Status** {} | object | This property describes the status and health of the resource and its children. See the *Resource* schema for details on this property. |
 | **VirtualFunctionsEnabled** | boolean<br><br>*read-only<br>(null)* | Whether Single Root I/O Virtualization (SR-IOV) Virual Functions (VFs) are enabled for this Network Device Function. |
 
-
-
 ## Property details
 
 ### AuthenticationMethod:
-
 
 The iSCSI boot authentication method for this network device function.
 
@@ -113,7 +108,6 @@ The iSCSI boot authentication method for this network device function.
 | None | No iSCSI authentication is used. |
 
 ### BootMode:
-
 
 The boot mode configured for this network device function.
 
@@ -127,7 +121,6 @@ The boot mode configured for this network device function.
 
 ### IPAddressType:
 
-
 The type of IP address (IPv6 or IPv4) being populated in the iSCSIBoot IP address fields.
 
 | string | Description |
@@ -136,7 +129,6 @@ The type of IP address (IPv6 or IPv4) being populated in the iSCSIBoot IP addres
 | IPv6 | IPv6 addressing is used for all IP-fields in this object. |
 
 ### NetDevFuncCapabilities:
-
 
 Capabilities of this network device function.
 
@@ -150,7 +142,6 @@ Capabilities of this network device function.
 
 ### NetDevFuncType:
 
-
 The configured capability of this network device function.
 
 | string | Description |
@@ -162,7 +153,6 @@ The configured capability of this network device function.
 | iSCSI | Appears to the operating system as an iSCSI device. |
 
 ### WWNSource:
-
 
 The configuration source of the WWNs for this connection (WWPN and WWNN).
 
@@ -177,8 +167,6 @@ The configuration source of the WWNs for this connection (WWPN and WWNN).
 
 ## Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **@odata.etag** | string<br><br>*read-only* | The current ETag of the resource. |
@@ -189,8 +177,6 @@ The configuration source of the WWNs for this connection (WWPN and WWNN).
 | **Name** | string<br><br>*read-only* | The name of the resource or array element. |
 | **Oem** {} | object | This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections. See the *Resource* schema for details on this property. |
 
-
-
 # NetworkPort 1.1.0
 
 ## Description
@@ -199,8 +185,6 @@ A Network Port represents a discrete physical port capable of connecting to a ne
 
 
 ## Properties
-
-
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -238,12 +222,9 @@ A Network Port represents a discrete physical port capable of connecting to a ne
 | } ] |   |   |
 | **WakeOnLANEnabled** | boolean<br><br>*read-write<br>(null)* | Whether Wake on LAN (WoL) is enabled for this network port. |
 
-
-
 ## Property details
 
 ### ActiveLinkTechnology:
-
 
 Network Port Active Link Technology.
 
@@ -254,7 +235,6 @@ Network Port Active Link Technology.
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
 
 ### FlowControlConfiguration:
-
 
 The locally configured 802.3x flow control setting for this network port.
 
@@ -267,7 +247,6 @@ The locally configured 802.3x flow control setting for this network port.
 
 ### FlowControlStatus:
 
-
 The 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only).
 
 | string | Description |
@@ -279,7 +258,6 @@ The 802.3x flow control behavior negotiated with the link partner for this netwo
 
 ### LinkNetworkTechnology:
 
-
 The self-described link network technology capabilities of this port.
 
 | string | Description |
@@ -290,7 +268,6 @@ The self-described link network technology capabilities of this port.
 
 ### LinkStatus:
 
-
 The status of the link between this port and its link partner.
 
 | string | Description |
@@ -299,7 +276,6 @@ The status of the link between this port and its link partner.
 | Up | The port is enabled and link is good (up). |
 
 ### SupportedEthernetCapabilities:
-
 
 The set of Ethernet capabilities that this port supports.
 

--- a/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/markdown_output.md
@@ -14,7 +14,7 @@ This schema contains one or more properties of type integer.
 
 ### Properties
 
-The properties defined for the IntegerTest 1.0.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "IntegerTest 1.0.0 properties").
+
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -27,4 +27,3 @@ The properties defined for the IntegerTest 1.0.0 schema are summarized in [Table
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Model** | string<br><br>*read-only<br>(null)* | The processor model for the primary or majority of processors in this system. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Status** {} | object | This type describes the status and health of a resource and its children. See the *Resource* schema for details on this property. |
 | } |   |   |
-Table: Table TBL_nn: <a name=table_TBL_nn>IntegerTest 1.0.0 properties</a>

--- a/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/markdown_output.md
@@ -14,8 +14,6 @@ This schema contains one or more properties of type integer.
 
 ### Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **Description** | string<br><br>*read-only<br>(null)* | Provides a description of this resource and is used for commonality  in the schema definitions. |

--- a/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/slate_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/slate_output.md
@@ -14,7 +14,7 @@ This schema contains one or more properties of type integer.
 
 ## Properties
 
-The properties defined for the IntegerTest 1.0.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "IntegerTest 1.0.0 properties").
+
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -27,4 +27,3 @@ The properties defined for the IntegerTest 1.0.0 schema are summarized in [Table
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Model** | string<br><br>*read-only<br>(null)* | The processor model for the primary or majority of processors in this system. |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Status** {} | object | This type describes the status and health of a resource and its children. See the *Resource* schema for details on this property. |
 | } |   |   |
-Table: Table TBL_nn: <a name=table_TBL_nn>IntegerTest 1.0.0 properties</a>

--- a/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/slate_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/integer/expected_output/slate_output.md
@@ -14,8 +14,6 @@ This schema contains one or more properties of type integer.
 
 ## Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **Description** | string<br><br>*read-only<br>(null)* | Provides a description of this resource and is used for commonality  in the schema definitions. |

--- a/doc-generator/tests/samples/generate_docs_cases/normative/expected_output/index.html
+++ b/doc-generator/tests/samples/generate_docs_cases/normative/expected_output/index.html
@@ -9,15 +9,11 @@
 </head>
 <body>
 <h2 id="NetworkDeviceFunction">NetworkDeviceFunction 1.3.2</h2>
-The revision history is summarized in [Table TBL_nn++](#table_TBL_nn "Revision history").
-
 <table>
 <tbody>
 <tr><td><b>Version</b></td><td><i>v1.3</i></td></tr>
 <tr><td><b>Release</b></td><td>2018.2</td></tr>
 </tbody></table>
-
-Table: Table TBL_nn: <a name=table_TBL_nn>Revision history</a>
 <p>A Network Device Function represents a logical interface exposed by the network adapter.</p>
 <table class="properties">
 <tbody>

--- a/doc-generator/tests/samples/generate_docs_cases/required/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/required/expected_output/markdown_output.md
@@ -14,7 +14,7 @@ This schema contains required and requiredOnCreate properties.
 
 ### Properties
 
-The properties defined for the RequiredTest 1.0.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "RequiredTest 1.0.0 properties").
+
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -27,14 +27,14 @@ The properties defined for the RequiredTest 1.0.0 schema are summarized in [Tabl
 | } |   |   |
 | **Id** | string<br><br>*read-only required* | Uniquely identifies the resource within the collection of like resources. |
 | **Name** | string<br><br>*read-only required* | The name of the resource or array element. |
-Table: Table TBL_nn: <a name=table_TBL_nn>RequiredTest 1.0.0 properties</a>
+
 
 
 ### Property details
 
 #### EntryType:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "EntryType property values").
+
 This is the type of log entry.
 
 | string | Description |
@@ -42,4 +42,3 @@ This is the type of log entry.
 | Event | Contains a Redfish-defined message (event). |
 | Oem | Contains an entry in an OEM-defined format. |
 | SEL | Contains a legacy IPMI System Event Log (SEL) entry. |
-Table: Table TBL_nn: <a name=table_TBL_nn>EntryType property values</a>

--- a/doc-generator/tests/samples/generate_docs_cases/required/expected_output/markdown_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/required/expected_output/markdown_output.md
@@ -14,8 +14,6 @@ This schema contains required and requiredOnCreate properties.
 
 ### Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **Description** | string<br><br>*read-only<br>(null)* | Provides a description of this resource and is used for commonality  in the schema definitions. |
@@ -28,12 +26,9 @@ This schema contains required and requiredOnCreate properties.
 | **Id** | string<br><br>*read-only required* | Uniquely identifies the resource within the collection of like resources. |
 | **Name** | string<br><br>*read-only required* | The name of the resource or array element. |
 
-
-
 ### Property details
 
 #### EntryType:
-
 
 This is the type of log entry.
 

--- a/doc-generator/tests/samples/generate_docs_cases/required/expected_output/slate_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/required/expected_output/slate_output.md
@@ -14,7 +14,7 @@ This schema contains required and requiredOnCreate properties.
 
 ## Properties
 
-The properties defined for the RequiredTest 1.0.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "RequiredTest 1.0.0 properties").
+
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -27,14 +27,14 @@ The properties defined for the RequiredTest 1.0.0 schema are summarized in [Tabl
 | } |   |   |
 | **Id** | string<br><br>*read-only required* | Uniquely identifies the resource within the collection of like resources. |
 | **Name** | string<br><br>*read-only required* | The name of the resource or array element. |
-Table: Table TBL_nn: <a name=table_TBL_nn>RequiredTest 1.0.0 properties</a>
+
 
 
 ## Property details
 
 ### EntryType:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "EntryType property values").
+
 This is the type of log entry.
 
 | string | Description |
@@ -42,4 +42,3 @@ This is the type of log entry.
 | Event | Contains a Redfish-defined message (event). |
 | Oem | Contains an entry in an OEM-defined format. |
 | SEL | Contains a legacy IPMI System Event Log (SEL) entry. |
-Table: Table TBL_nn: <a name=table_TBL_nn>EntryType property values</a>

--- a/doc-generator/tests/samples/generate_docs_cases/required/expected_output/slate_output.md
+++ b/doc-generator/tests/samples/generate_docs_cases/required/expected_output/slate_output.md
@@ -14,8 +14,6 @@ This schema contains required and requiredOnCreate properties.
 
 ## Properties
 
-
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **Description** | string<br><br>*read-only<br>(null)* | Provides a description of this resource and is used for commonality  in the schema definitions. |
@@ -28,12 +26,9 @@ This schema contains required and requiredOnCreate properties.
 | **Id** | string<br><br>*read-only required* | Uniquely identifies the resource within the collection of like resources. |
 | **Name** | string<br><br>*read-only required* | The name of the resource or array element. |
 
-
-
 ## Property details
 
 ### EntryType:
-
 
 This is the type of log entry.
 

--- a/doc-generator/tests/samples/pattern_properties/expected_output/MessagesPropertyDetails.md
+++ b/doc-generator/tests/samples/pattern_properties/expected_output/MessagesPropertyDetails.md
@@ -1,19 +1,16 @@
 ### ClearsIf:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "ClearsIf property values").
 This property contains the available OEM specific actions for this resource.
 
 | string | Description |
 | --- | --- |
 | SameOriginOfCondition | Indicates the message is cleared by the other message(s) listed in the ClearingLogic object, provided the OriginOfCondition for both Events are the same. |
-Table: Table TBL_nn: <a name=table_TBL_nn>ClearsIf property values</a>
+
 ### ParamTypes:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "ParamTypes property values").
 The MessageArg types, in order, for the message.
 
 | string | Description |
 | --- | --- |
 | number | The parameter is a number. |
 | string | The parameter is a string. |
-Table: Table TBL_nn: <a name=table_TBL_nn>ParamTypes property values</a>

--- a/doc-generator/tests/samples/referenced_objects/network_sample_output/output.md
+++ b/doc-generator/tests/samples/referenced_objects/network_sample_output/output.md
@@ -16,13 +16,9 @@ Oem extension object.
 
 ## Properties
 
-The properties defined for the Oem schema are summarized in [Table TBL_nn++](#table_TBL_nn "Oem properties").
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **(pattern)** {} | object | Property names follow regular expression pattern "\[A\-Za\-z0\-9\_\.:\]\+" |
-Table: Table TBL_nn: <a name=table_TBL_nn>Oem properties</a>
-
 
 # Status
 
@@ -33,8 +29,6 @@ This type describes the status and health of a resource and its children.
 
 ## Properties
 
-The properties defined for the Status schema are summarized in [Table TBL_nn++](#table_TBL_nn "Status properties").
-
 |Property     |Type     |Notes     |
 | --- | --- | --- |
 | **Health** | string<br>(enum)<br><br>*read-only<br>(null)* | This represents the health state of this resource in the absence of its dependent resources. *For the possible property values, see Health in Property details.* |
@@ -43,14 +37,11 @@ The properties defined for the Status schema are summarized in [Table TBL_nn++](
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**(pattern)** {} | object | Property names follow regular expression pattern "\[A\-Za\-z0\-9\_\.:\]\+" |
 | } |   |   |
 | **State** | string<br>(enum)<br><br>*read-only<br>(null)* | This indicates the known state of the resource, such as if it is enabled. *For the possible property values, see State in Property details.* |
-Table: Table TBL_nn: <a name=table_TBL_nn>Status properties</a>
-
 
 ## Property details
 
 ### Health:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "Health property values").
 This represents the health state of this resource in the absence of its dependent resources.
 
 | string | Description |
@@ -58,10 +49,9 @@ This represents the health state of this resource in the absence of its dependen
 | Critical | A critical condition exists that requires immediate attention. |
 | OK | Normal. |
 | Warning | A condition exists that requires attention. |
-Table: Table TBL_nn: <a name=table_TBL_nn>Health property values</a>
+
 ### HealthRollup:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "HealthRollup property values").
 This represents the overall health state from the view of this resource.
 
 | string | Description |
@@ -69,10 +59,9 @@ This represents the overall health state from the view of this resource.
 | Critical | A critical condition exists that requires immediate attention. |
 | OK | Normal. |
 | Warning | A condition exists that requires attention. |
-Table: Table TBL_nn: <a name=table_TBL_nn>HealthRollup property values</a>
+
 ### State:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "State property values").
 This indicates the known state of the resource, such as if it is enabled.
 
 | string | Description |
@@ -88,7 +77,7 @@ This indicates the known state of the resource, such as if it is enabled.
 | Starting | This function or resource is starting. |
 | UnavailableOffline | This function or resource is present but cannot be used. |
 | Updating | The element is updating and may be unavailable or degraded. |
-Table: Table TBL_nn: <a name=table_TBL_nn>State property values</a>
+
 
 
 # NetworkDeviceFunction 1.2.1
@@ -99,8 +88,6 @@ A Network Device Function represents a logical interface exposed by the network 
 
 
 ## Properties
-
-The properties defined for the NetworkDeviceFunction 1.2.1 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunction 1.2.1 properties").
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -172,14 +159,11 @@ The properties defined for the NetworkDeviceFunction 1.2.1 schema are summarized
 | } |   |   |
 | **Status** {} | object<br><br>*<br>(null)* | This type describes the status and health of a resource and its children. For property details, see Status. |
 | **VirtualFunctionsEnabled** | boolean<br><br>*read-only<br>(null)* | Whether Single Root I/O Virtualization (SR-IOV) Virual Functions (VFs) are enabled for this Network Device Function. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetworkDeviceFunction 1.2.1 properties</a>
-
 
 ## Property details
 
 ### AuthenticationMethod:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "AuthenticationMethod property values").
 The iSCSI boot authentication method for this network device function.
 
 | string | Description |
@@ -187,10 +171,9 @@ The iSCSI boot authentication method for this network device function.
 | CHAP | iSCSI Challenge Handshake Authentication Protocol (CHAP) authentication is used. |
 | MutualCHAP | iSCSI Mutual Challenge Handshake Authentication Protocol (CHAP) authentication is used. |
 | None | No iSCSI authentication is used. |
-Table: Table TBL_nn: <a name=table_TBL_nn>AuthenticationMethod property values</a>
+
 ### BootMode:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "BootMode property values").
 The boot mode configured for this network device function.
 
 | string | Description |
@@ -200,20 +183,18 @@ The boot mode configured for this network device function.
 | FibreChannelOverEthernet | Boot this device using the embedded Fibre Channel over Ethernet (FCoE) boot support and configuration.  Only applicable if the NetworkDeviceFunctionType is set to FibreChannelOverEthernet. |
 | iSCSI | Boot this device using the embedded iSCSI boot support and configuration.  Only applicable if the NetworkDeviceFunctionType is set to iSCSI. |
 | PXE | Boot this device using the embedded PXE support.  Only applicable if the NetworkDeviceFunctionType is set to Ethernet. |
-Table: Table TBL_nn: <a name=table_TBL_nn>BootMode property values</a>
+
 ### IPAddressType:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "IPAddressType property values").
 The type of IP address (IPv6 or IPv4) being populated in the iSCSIBoot IP address fields.
 
 | string | Description |
 | --- | --- |
 | IPv4 | IPv4 addressing is used for all IP-fields in this object. |
 | IPv6 | IPv6 addressing is used for all IP-fields in this object. |
-Table: Table TBL_nn: <a name=table_TBL_nn>IPAddressType property values</a>
+
 ### NetDevFuncCapabilities:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "NetDevFuncCapabilities property values").
 Capabilities of this network device function.
 
 | string | Description |
@@ -223,10 +204,9 @@ Capabilities of this network device function.
 | FibreChannel | Appears to the operating system as a Fibre Channel device. |
 | FibreChannelOverEthernet | Appears to the operating system as an FCoE device. |
 | iSCSI | Appears to the operating system as an iSCSI device. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetDevFuncCapabilities property values</a>
+
 ### NetDevFuncType:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "NetDevFuncType property values").
 The configured capability of this network device function.
 
 | string | Description |
@@ -236,24 +216,21 @@ The configured capability of this network device function.
 | FibreChannel | Appears to the operating system as a Fibre Channel device. |
 | FibreChannelOverEthernet | Appears to the operating system as an FCoE device. |
 | iSCSI | Appears to the operating system as an iSCSI device. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetDevFuncType property values</a>
+
 ### WWNSource:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "WWNSource property values").
 The configuration source of the WWNs for this connection (WWPN and WWNN).
 
 | string | Description |
 | --- | --- |
 | ConfiguredLocally | The set of FC/FCoE boot targets was applied locally through API or UI. |
 | ProvidedByFabric | The set of FC/FCoE boot targets was applied by the Fibre Channel fabric. |
-Table: Table TBL_nn: <a name=table_TBL_nn>WWNSource property values</a>
+
 
 # NetworkDeviceFunctionCollection
 
 
 ## Properties
-
-The properties defined for the NetworkDeviceFunctionCollection schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkDeviceFunctionCollection properties").
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -264,8 +241,6 @@ The properties defined for the NetworkDeviceFunctionCollection schema are summar
 | } ] |   |   |
 | **Name** | string<br><br>*read-only* | The name of the resource or array element. |
 | **Oem** {} | object | This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections. For property details, see Oem. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetworkDeviceFunctionCollection properties</a>
-
 
 # NetworkPort 1.1.0
 
@@ -275,8 +250,6 @@ A Network Port represents a discrete physical port capable of connecting to a ne
 
 
 ## Properties
-
-The properties defined for the NetworkPort 1.1.0 schema are summarized in [Table TBL_nn++](#table_TBL_nn "NetworkPort 1.1.0 properties").
 
 |Property     |Type     |Notes     |
 | --- | --- | --- |
@@ -313,14 +286,11 @@ The properties defined for the NetworkPort 1.1.0 schema are summarized in [Table
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**LinkSpeedMbps** | number<br><br>*read-only<br>(null)* | The speed of the link in Mbps when this link network technology is active. |
 | } ] |   |   |
 | **WakeOnLANEnabled** | boolean<br><br>*read-write<br>(null)* | Whether Wake on LAN (WoL) is enabled for this network port. |
-Table: Table TBL_nn: <a name=table_TBL_nn>NetworkPort 1.1.0 properties</a>
-
 
 ## Property details
 
 ### ActiveLinkTechnology:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "ActiveLinkTechnology property values").
 Network Port Active Link Technology.
 
 | string | Description |
@@ -328,10 +298,9 @@ Network Port Active Link Technology.
 | Ethernet | The port is capable of connecting to an Ethernet network. |
 | FibreChannel | The port is capable of connecting to a Fibre Channel network. |
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
-Table: Table TBL_nn: <a name=table_TBL_nn>ActiveLinkTechnology property values</a>
+
 ### FlowControlConfiguration:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "FlowControlConfiguration property values").
 The locally configured 802.3x flow control setting for this network port.
 
 | string | Description |
@@ -340,10 +309,9 @@ The locally configured 802.3x flow control setting for this network port.
 | RX | IEEE 802.3x flow control may be initiated by the link partner. |
 | TX | IEEE 802.3x flow control may be initiated by this station. |
 | TX_RX | IEEE 802.3x flow control may be initiated by this station or the link partner. |
-Table: Table TBL_nn: <a name=table_TBL_nn>FlowControlConfiguration property values</a>
+
 ### FlowControlStatus:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "FlowControlStatus property values").
 The 802.3x flow control behavior negotiated with the link partner for this network port (Ethernet-only).
 
 | string | Description |
@@ -352,10 +320,9 @@ The 802.3x flow control behavior negotiated with the link partner for this netwo
 | RX | IEEE 802.3x flow control may be initiated by the link partner. |
 | TX | IEEE 802.3x flow control may be initiated by this station. |
 | TX_RX | IEEE 802.3x flow control may be initiated by this station or the link partner. |
-Table: Table TBL_nn: <a name=table_TBL_nn>FlowControlStatus property values</a>
+
 ### LinkNetworkTechnology:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "LinkNetworkTechnology property values").
 The self-described link network technology capabilities of this port.
 
 | string | Description |
@@ -363,24 +330,21 @@ The self-described link network technology capabilities of this port.
 | Ethernet | The port is capable of connecting to an Ethernet network. |
 | FibreChannel | The port is capable of connecting to a Fibre Channel network. |
 | InfiniBand | The port is capable of connecting to an InfiniBand network. |
-Table: Table TBL_nn: <a name=table_TBL_nn>LinkNetworkTechnology property values</a>
+
 ### LinkStatus:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "LinkStatus property values").
 The status of the link between this port and its link partner.
 
 | string | Description |
 | --- | --- |
 | Down | The port is enabled but link is down. |
 | Up | The port is enabled and link is good (up). |
-Table: Table TBL_nn: <a name=table_TBL_nn>LinkStatus property values</a>
+
 ### SupportedEthernetCapabilities:
 
-The defined property values are listed in [Table TBL_nn++](#table_TBL_nn "SupportedEthernetCapabilities property values").
 The set of Ethernet capabilities that this port supports.
 
 | string | Description |
 | --- | --- |
 | EEE | IEEE 802.3az Energy Efficient Ethernet (EEE) is supported on this port. |
 | WakeOnLAN | Wake on LAN (WoL) is supported on this port. |
-Table: Table TBL_nn: <a name=table_TBL_nn>SupportedEthernetCapabilities property values</a>

--- a/doc-generator/tests/test_generate_docs.py
+++ b/doc-generator/tests/test_generate_docs.py
@@ -81,25 +81,28 @@ def test_html_output(mockRequest):
 
 
 @patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
-def test_markdown_output(mockRequest):
+def test_markdown_with_table_numbering_output(mockRequest):
 
     config = copy.deepcopy(base_config)
     config['output_format'] = 'markdown'
+    config['with_table_numbering'] = True
 
-    for dirname, name in cases.items():
-        dirpath = os.path.abspath(os.path.join(testcase_path, dirname))
-        input_dir = os.path.join(dirpath, 'input')
+    # We're just doing one test case for table numbering; it's sufficient.
+    dirname = 'general'
+    name = cases.get(dirname)
+    dirpath = os.path.abspath(os.path.join(testcase_path, dirname))
+    input_dir = os.path.join(dirpath, 'input')
 
-        config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
-        config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
+    config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
+    config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
 
-        expected_output = open(os.path.join(dirpath, 'expected_output', 'markdown_output.md')).read().strip()
+    expected_output = open(os.path.join(dirpath, 'expected_output', 'markdown_with_table_numbering_output.md')).read().strip()
 
-        docGen = DocGenerator([ input_dir ], '/dev/null', config)
-        output = docGen.generate_docs()
-        output = output.strip()
+    docGen = DocGenerator([ input_dir ], '/dev/null', config)
+    output = docGen.generate_docs()
+    output = output.strip()
 
-        assert output == expected_output, "Failed on: " + name
+    assert output == expected_output, "Failed on: " + name
 
 
 @patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
@@ -116,6 +119,28 @@ def test_slate_output(mockRequest):
         config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
 
         expected_output = open(os.path.join(dirpath, 'expected_output', 'slate_output.md')).read().strip()
+
+        docGen = DocGenerator([ input_dir ], '/dev/null', config)
+        output = docGen.generate_docs()
+        output = output.strip()
+
+        assert output == expected_output, "Failed on: " + name
+
+
+@patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
+def test_markdown_output(mockRequest):
+
+    config = copy.deepcopy(base_config)
+    config['output_format'] = 'markdown'
+
+    for dirname, name in cases.items():
+        dirpath = os.path.abspath(os.path.join(testcase_path, dirname))
+        input_dir = os.path.join(dirpath, 'input')
+
+        config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
+        config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
+
+        expected_output = open(os.path.join(dirpath, 'expected_output', 'markdown_output.md')).read().strip()
 
         docGen = DocGenerator([ input_dir ], '/dev/null', config)
         output = docGen.generate_docs()


### PR DESCRIPTION
Adds a "with_table_numbering" config option (boolean, to be specified in the config file) to turn on the ISO table numbering feature. Default is off; option is ignored for HTML output. 

