### PR TITLE
Carry over output_format config value to fragment generator.

### DIFF
--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -825,6 +825,7 @@ search: true
             'profile_resources': self.config.get('profile_resources', {}),
             'wants_common_objects': self.config.get('wants_common_objects'),
             'actions_in_property_table': self.config.get('actions_in_property_table', True),
+            'output_format': self.config.get('output_format')
             }
 
         for line in intro_blob.splitlines():

--- a/doc-generator/tests/samples/fragments/CommonPropertySchema.json
+++ b/doc-generator/tests/samples/fragments/CommonPropertySchema.json
@@ -1,0 +1,225 @@
+{
+   "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_2_0.json",
+   "title": "CommonProperties",
+   "$ref": "#/definitions/CommonProperties",
+   "definitions": {
+      "CommonProperties": {
+         "type": "object",
+         "additionalProperties": false,
+         "properties": {
+            "@odata.context": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/context",
+               "description": "The URL to a metadata document with a fragment that describes the data, which is typically rooted at the top-level singleton or collection.  Technically, the metadata document has to only define, or reference, any of the types that it directly uses, and different payloads could reference different metadata documents. However, because this property provides a root URL for resolving a relative reference, such as `@odata.id`, the API returns the canonical metadata document."
+            },
+            "@odata.etag": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_2.json#/definitions/etag",
+               "type": "string",
+               "readonly": true,
+               "description": "The current ETag for the Resource."
+            },
+            "@odata.id": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/id",
+               "description": "The unique ID for the Resource."
+            },
+            "@odata.type": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/type"
+            },
+            "Description": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description",
+               "readonly": true,
+               "description": "The human-readable description for the Resource."
+            },
+            "Id": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+               "readonly": true,
+               "description": "The ID that uniquely identifies the Resource within the collection that contains it.  This value is unique within a collection."
+            },
+            "Name": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+               "readonly": true,
+               "description": "The human-readable moniker for a Resource.  The type is string.  The value is NOT necessarily unique across Resource instances within a collection."
+            },
+            "Oem": {
+               "type": "object",
+               "description": "The manufacturer- or provider-specific extension moniker that divides the `Oem` object into sections."
+            }
+         },
+         "required": [
+            "@odata.id",
+            "@odata.type",
+            "Name"
+         ]
+      },
+      "FrequentProperties": {
+         "type": "object",
+         "additionalProperties": false,
+         "properties": {
+            "Actions": {
+               "type": "object",
+               "description": "The Redfish actions available for this Resource.",
+               "properties": {
+                  "target": {
+                     "type": "string",
+                     "description": "**** TBD ****"
+                  }
+               }
+            },
+            "Links": {
+               "type": "object",
+               "description": "The links associated with the Resource, as defined by that Resource's schema definition.  All associated reference properties defined for a Resource are nested under the Links property.  Find all directly referenced, or subordinate, Resource properties from the root of the Resource."
+            },
+            "RelatedItem": {
+               "items": {
+                  "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_2.json#/definitions/idRef"
+               },
+               "readonly": true,
+               "type": "array",
+               "description": "An array of links.  Each link points to a Resource or part of a Resource as defined by that Resource's schema.  This representation is not intended to be a strong linking methodology like other references.  Instead, it shows a relationship between elements or subelements in disparate parts of the service.  For example, fans might be in one area of the system and processors in another.  The relationship between the two might not be obvious.  This property can show that one is related to the other.  In this example, it might indicate that a specific fan cools a specific processor."
+            }
+         }
+      },
+      "ActionDetails": {
+         "type": "object",
+         "additionalProperties": false,
+         "description": "The Redfish actions available for this Resource.",
+         "properties": {
+            "#{action name}": {
+               "type": "object",
+               "readonly": true,
+               "description": "A single Redfish action.",
+               "properties": {
+                  "target": {
+                     "type": "string",
+                     "readonly": true,
+                     "description": "The target URI for the POST operation to invoke the action."
+                  },
+                  "@Redfish.ActionInfo": {
+                     "type": "string",
+                     "readonly": true,
+                     "description": "The URI for an ActionInfo Resource that describes this action."
+                  }
+               }
+            }
+         }
+      },
+      "Collection": {
+         "type": "object",
+         "properties": {
+            "@odata.context": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/context"
+            },
+            "@odata.id": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/id"
+            },
+            "@odata.type": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/type"
+            },
+            "Description": {
+               "anyOf": [{
+                     "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                  },
+                  {
+                     "type": "null"
+                  }
+               ],
+               "readonly": true
+            },
+            "Name": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+               "readonly": true
+            },
+            "Oem": {
+               "type": "object",
+               "description": "The manufacturer- or provider-specific extension moniker that divides the `Oem` object into sections.",
+               "longDescription": "This string property shall be in the `Oem` reserved word format."
+            },
+            "Members@odata.count": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/count"
+            },
+            "Members@odata.navigationLink": {
+               "type": "string",
+               "format": "uri"
+            },
+            "Members": {
+               "type": "array",
+               "items": {
+                  "type": "object",
+                  "properties": {
+                     "@odata.id": {
+                        "type": "string",
+                        "format": "uri",
+                        "readonly": true,
+                        "description": "The link to a Resource instance, which is a member of this collection."
+                     }
+                  }
+               },
+               "readonly": true,
+               "description": "The members of this collection."
+            }
+         },
+         "required": [
+            "@odata.id",
+            "@odata.type",
+            "Name",
+            "Members"
+         ]
+      },
+      "PropertyAnnotations": {
+         "type": "object",
+         "properties": {
+            "@Redfish.AllowableValues": {
+               "type": "array",
+               "readonly": true,
+               "description": "The string values that a service accepts for a property or action parameter.",
+               "items": {
+                  "type": "string"
+               }
+            },
+            "@Message.ExtendedInfo": {
+               "type": "object",
+               "readonly": true,
+               "description": "The additional information for a set of message structures for a property.  These messages can be useful when a property is `null` due to an error condition and the service wants to convey why the property is `null`."
+            },
+            "@odata.count": {
+               "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/count"
+            }
+         }
+      },
+      "ResourceAnnotations": {
+         "type": "object",
+         "properties": {
+            "@Redfish.ActionInfo": {
+               "description": "The URI to an ActionInfo Resource, which describes the parameters that this Action instance supports.",
+               "type": "string",
+               "format": "uri",
+               "readonly": true
+            },
+            "@Redfish.Settings": {
+               "description": "The reference to the Resource that represents the settings to apply to this object.",
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Settings.json#/definitions/Settings"
+            },
+            "@Redfish.SettingsApplyTime": {
+               "description": "The configuration settings that define when to apply the settings to a Resource.",
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Settings.json#/definitions/PreferredApplyTime"
+            },
+            "@Redfish.OperationApplyTime": {
+               "description": "The client's requested apply time to complete a create, delete, or action operation.",
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Settings.json#/definitions/OperationApplyTime"
+            },
+            "@Redfish.OperationApplyTimeSupport": {
+               "description": "An indication of whether a client can request a specific apply time for a create, delete, or action operation for a Resource through the OperationApplyTime term.",
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Settings.json#/definitions/OperationApplyTimeSupport"
+            },
+            "@Redfish.MaintenanceWindow": {
+               "description": "The maintenance window configuration that defines when to apply settings or operations to a Resource.",
+               "$ref": "http://redfish.dmtf.org/schemas/v1/Settings.json#/definitions/MaintenanceWindow"
+            },
+            "@Redfish.CollectionCapabilities": {
+               "description": "The reference to the Resource that represents the POST capabilities of a collection.",
+               "$ref": "http://redfish.dmtf.org/schemas/v1/CollectionCapabilities.json#/definitions/CollectionCapabilities"
+            }
+         }
+      },
+      "copyright": "Copyright 2014-2018 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright"
+   }
+}

--- a/doc-generator/tests/samples/fragments/expected_output.html
+++ b/doc-generator/tests/samples/fragments/expected_output.html
@@ -1,0 +1,12 @@
+<h1 id="fragment-follows">FRAGMENT FOLLOWS</h1>
+
+<table class="properties">
+<tbody>
+<tr><td><nobr><b>@odata.context</b></nobr></td><td>string<br>(URI)</td><td><nobr>read-only</nobr></td><td>The URL to a metadata document with a fragment that describes the data, which is typically rooted at the top-level singleton or collection.  Technically, the metadata document has to only define, or reference, any of the types that it directly uses, and different payloads could reference different metadata documents. However, because this property provides a root URL for resolving a relative reference, such as <code>@odata.id</code>, the API returns the canonical metadata document.</td></tr>
+<tr><td><nobr><b>@odata.etag</b></nobr></td><td>string</td><td><nobr>read-only</nobr></td><td>The current ETag for the Resource.</td></tr>
+<tr><td><nobr><b>@odata.id</b></nobr></td><td>string<br>(URI)</td><td><nobr>read-only</nobr> <nobr>required</nobr></td><td>The unique ID for the Resource.</td></tr>
+<tr><td><nobr><b>@odata.type</b></nobr></td><td>string</td><td><nobr>read-only</nobr> <nobr>required</nobr></td><td>The type of a resource.</td></tr>
+<tr><td><nobr><b>Description</b></nobr></td><td>string</td><td><nobr>read-only</nobr></td><td>The human-readable description for the Resource.</td></tr>
+<tr><td><nobr><b>Id</b></nobr></td><td>string</td><td><nobr>read-only</nobr></td><td>The ID that uniquely identifies the Resource within the collection that contains it.  This value is unique within a collection.</td></tr>
+<tr><td><nobr><b>Name</b></nobr></td><td>string</td><td><nobr>read-only</nobr> <nobr>required</nobr></td><td>The human-readable moniker for a Resource.  The type is string.  The value is NOT necessarily unique across Resource instances within a collection.</td></tr>
+<tr><td><nobr><b>Oem</b> { }</nobr></td><td>object</td><td></td><td>The manufacturer- or provider-specific extension moniker that divides the <code>Oem</code> object into sections.</td></tr>

--- a/doc-generator/tests/samples/fragments/expected_output.md
+++ b/doc-generator/tests/samples/fragments/expected_output.md
@@ -1,0 +1,16 @@
+# FRAGMENT FOLLOWS
+
+
+
+### Properties
+
+|Property     |Type     |Attributes   |Notes     |
+| --- | --- | --- | --- |
+| **@odata.context** | string<br>(URI) | *read-only* | The URL to a metadata document with a fragment that describes the data, which is typically rooted at the top-level singleton or collection.  Technically, the metadata document has to only define, or reference, any of the types that it directly uses, and different payloads could reference different metadata documents. However, because this property provides a root URL for resolving a relative reference, such as `@odata.id`, the API returns the canonical metadata document. |
+| **@odata.etag** | string | *read-only* | The current ETag for the Resource. |
+| **@odata.id** | string<br>(URI) | *read-only required* | The unique ID for the Resource. |
+| **@odata.type** | string | *read-only required* | The type of a resource. |
+| **Description** | string | *read-only* | The human-readable description for the Resource. |
+| **Id** | string | *read-only* | The ID that uniquely identifies the Resource within the collection that contains it.  This value is unique within a collection. |
+| **Name** | string | *read-only required* | The human-readable moniker for a Resource.  The type is string.  The value is NOT necessarily unique across Resource instances within a collection. |
+| **Oem** {} | object |  | The manufacturer- or provider-specific extension moniker that divides the `Oem` object into sections. |

--- a/doc-generator/tests/samples/fragments/expected_slate_output.md
+++ b/doc-generator/tests/samples/fragments/expected_slate_output.md
@@ -1,0 +1,16 @@
+# FRAGMENT FOLLOWS
+
+
+
+## Properties
+
+|Property     |Type     |Notes     |
+| --- | --- | --- |
+| **@odata.context** | string<br>(URI)<br><br>*read-only* | The URL to a metadata document with a fragment that describes the data, which is typically rooted at the top-level singleton or collection.  Technically, the metadata document has to only define, or reference, any of the types that it directly uses, and different payloads could reference different metadata documents. However, because this property provides a root URL for resolving a relative reference, such as `@odata.id`, the API returns the canonical metadata document. |
+| **@odata.etag** | string<br><br>*read-only* | The current ETag for the Resource. |
+| **@odata.id** | string<br>(URI)<br><br>*read-only required* | The unique ID for the Resource. |
+| **@odata.type** | string<br><br>*read-only required* | The type of a resource. |
+| **Description** | string<br><br>*read-only* | The human-readable description for the Resource. |
+| **Id** | string<br><br>*read-only* | The ID that uniquely identifies the Resource within the collection that contains it.  This value is unique within a collection. |
+| **Name** | string<br><br>*read-only required* | The human-readable moniker for a Resource.  The type is string.  The value is NOT necessarily unique across Resource instances within a collection. |
+| **Oem** {} | object | The manufacturer- or provider-specific extension moniker that divides the `Oem` object into sections. |

--- a/doc-generator/tests/samples/fragments/json-schema/IntegerTest.json
+++ b/doc-generator/tests/samples/fragments/json-schema/IntegerTest.json
@@ -1,0 +1,21 @@
+{
+    "$ref": "#/definitions/IntegerTest",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_4_0.json",
+    "copyright": "Copyright 2014-2018 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "IntegerTest": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/idRef"
+                },
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/IntegerTest.v1_0_0.json#/definitions/IntegerTest"
+                }
+            ],
+            "description": "The IntegerTest schema contains an example of a property with type integer.",
+            "longDescription": "The IntegerTest schema contains an example of a property with type integer."
+        }
+    },
+    "owningEntity": "DMTF",
+    "title": "#IntegerTest.IntegerTest"
+}

--- a/doc-generator/tests/samples/fragments/json-schema/IntegerTest.v1_0_0.json
+++ b/doc-generator/tests/samples/fragments/json-schema/IntegerTest.v1_0_0.json
@@ -1,0 +1,125 @@
+{
+    "$ref": "#/definitions/IntegerTest",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_3_0.json",
+    "copyright": "Copyright 2014-2017 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "IntegerTest": {
+            "additionalProperties": false,
+            "description": "This schema contains one or more properties of type integer.",
+            "longDescription": "This schema contains one or more properties of type integer.",
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/context"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/type"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Links": {
+                    "$ref": "#/definitions/Links",
+                    "description": "Contains references to other resources that are related to this resource.",
+                    "longDescription": "The Links property, as described by the Redfish Specification, shall contain references to resources that are related to, but not contained by (subordinate to), this resource."
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "ProcessorSummary": {
+                    "$ref": "#/definitions/ProcessorSummary",
+                    "description": "This object describes the central processors of the system in general detail.",
+                    "longDescription": "This object shall contain properties which describe the central processors for the current resource."
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ProcessorSummary": {
+            "additionalProperties": false,
+            "description": "This object describes the central processors of the system in general detail.",
+            "longDescription": "This type shall contain properties which describe the central processors for a system.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Count": {
+                    "description": "The number of physical processors in the system.",
+                    "longDescription": "This property shall contain the number of physical central processors in the system.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "LogicalProcessorCount": {
+                    "description": "The number of logical processors in the system.",
+                    "longDescription": "This property shall contain the number of logical central processors in the system.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "Model": {
+                    "description": "The processor model for the primary or majority of processors in this system.",
+                    "longDescription": "This property shall contain the processor model for the central processors in the system, per the description in the Processor Information - Processor Family section of the SMBIOS Specification DSP0134 2.8 or later.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status"
+                }
+            },
+            "type": "object"
+        },
+        "Links": {
+            "additionalProperties": false,
+            "description": "Contains references to other resources that are related to this resource.",
+            "longDescription": "This type, as described by the Redfish Specification, shall contain references to resources that are related to, but not contained by (subordinate to), this resource.",
+            "properties": {
+                "PoweredBy": {
+                    "description": "An array of ID[s] of resources that power this computer system. Normally the ID will be a chassis or a specific set of Power Supplies.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/idRef"
+                    },
+                    "longDescription": "The value of this property shall be an array of IDs containing pointers consistent with JSON pointer syntax to the resource that powers this computer system.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "PoweredBy@odata.count": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_3.json#/definitions/count"
+                }
+            }
+        }
+    },
+    "title": "#IntegerTest.v1_0_0.IntegerTest"
+}

--- a/doc-generator/tests/samples/fragments/json-schema/Resource.json
+++ b/doc-generator/tests/samples/fragments/json-schema/Resource.json
@@ -1,0 +1,317 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_4_0.json",
+    "copyright": "Copyright 2014-2018 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Description": {
+            "description": "Provides a description of this resource and is used for commonality  in the schema definitions.",
+            "longDescription": "This object represents the Description property.  All values for resources described by this schema shall comply to the requirements as described in the Redfish specification.",
+            "type": "string"
+        },
+        "Health": {
+            "enum": [
+                "OK",
+                "Warning",
+                "Critical"
+            ],
+            "enumDescriptions": {
+                "Critical": "A critical condition exists that requires immediate attention.",
+                "OK": "Normal.",
+                "Warning": "A condition exists that requires attention."
+            },
+            "type": "string"
+        },
+        "Id": {
+            "description": "Uniquely identifies the resource within the collection of like resources.",
+            "longDescription": "This property represents an identifier for the resource.  All values for resources described by this schema shall comply to the requirements as described in the Redfish specification.",
+            "type": "string"
+        },
+        "Identifier": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_6_0.json#/definitions/Identifier"
+                }
+            ],
+            "description": "This type describes any additional identifiers for a resource.",
+            "longDescription": "This type shall contain any additional identifiers of a resource."
+        },
+        "IndicatorLED": {
+            "enum": [
+                "Lit",
+                "Blinking",
+                "Off"
+            ],
+            "enumDescriptions": {
+                "Blinking": "The Indicator LED is blinking.",
+                "Lit": "The Indicator LED is lit.",
+                "Off": "The Indicator LED is off."
+            },
+            "enumLongDescriptions": {
+                "Blinking": "This value shall represent the Indicator LED is in a blinking state where the LED is being turned on and off in repetition.  If this value is not supported by the service, the service shall reject PATCH or PUT requests containing this value by returning HTTP 400 (Bad Request).",
+                "Lit": "This value shall represent the Indicator LED is in a solid on state.  If this value is not supported by the service, the service shall reject PATCH or PUT requests containing this value by returning HTTP 400 (Bad Request).",
+                "Off": "This value shall represent the Indicator LED is in a solid off state.  If this value is not supported by the service, the service shall reject PATCH or PUT requests containing this value by returning HTTP 400 (Bad Request)."
+            },
+            "type": "string"
+        },
+        "Item": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ReferenceableMember"
+                },
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                }
+            ],
+            "description": "This is the base type for resources and referenceable members."
+        },
+        "ItemOrCollection": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Item"
+                },
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResourceCollection"
+                }
+            ]
+        },
+        "Links": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "Oem extension object.",
+                    "longDescription": "This object represents the Oem property.  All values for resources described by this schema shall comply to the requirements as described in the Redfish specification."
+                }
+            },
+            "type": "object"
+        },
+        "Location": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_6_0.json#/definitions/Location"
+                }
+            ],
+            "description": "This type describes the location of a resource.",
+            "longDescription": "This type shall describe the location of a resource."
+        },
+        "Name": {
+            "description": "The name of the resource or array element.",
+            "longDescription": "This object represents the Name property.  All values for resources described by this schema shall comply to the requirements as described in the Redfish specification. The value of this string shall be of the format for the reserved word *Name*.",
+            "type": "string"
+        },
+        "Oem": {
+            "additionalProperties": true,
+            "description": "Oem extension object.",
+            "longDescription": "This object represents the Oem properties.  All values for resources described by this schema shall comply to the requirements as described in the Redfish specification.",
+            "patternProperties": {
+                "[A-Za-z0-9_.:]+": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/OemObject"
+                },
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "OemObject": {
+            "additionalProperties": true,
+            "description": "Base type for an Oem object.",
+            "longDescription": "This object represents the base type for an Oem property.  All values for resources described by this schema shall comply to the requirements as described in the Redfish specification.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerState": {
+            "enum": [
+                "On",
+                "Off",
+                "PoweringOn",
+                "PoweringOff"
+            ],
+            "enumDescriptions": {
+                "Off": "The state is powered Off.",
+                "On": "The state is powered On.",
+                "PoweringOff": "A temporary state between On and Off.",
+                "PoweringOn": "A temporary state between Off and On."
+            },
+            "type": "string"
+        },
+        "ReferenceableMember": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_0_0.json#/definitions/ReferenceableMember"
+                }
+            ]
+        },
+        "ResetType": {
+            "enum": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton",
+                "PowerCycle"
+            ],
+            "enumDescriptions": {
+                "ForceOff": "Turn the unit off immediately (non-graceful shutdown).",
+                "ForceOn": "Turn the unit on immediately.",
+                "ForceRestart": "Perform an immediate (non-graceful) shutdown, followed by a restart.",
+                "GracefulRestart": "Perform a graceful shutdown followed by a restart of the system.",
+                "GracefulShutdown": "Perform a graceful shutdown and power off.",
+                "Nmi": "Generate a Diagnostic Interrupt (usually an NMI on x86 systems) to cease normal operations, perform diagnostic actions and typically halt the system.",
+                "On": "Turn the unit on.",
+                "PowerCycle": "Perform a power cycle of the unit.",
+                "PushPowerButton": "Simulate the pressing of the physical power button on this unit."
+            },
+            "type": "string"
+        },
+        "Resource": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_0_0.json#/definitions/Resource"
+                }
+            ]
+        },
+        "ResourceCollection": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_0_0.json#/definitions/ResourceCollection"
+                }
+            ]
+        },
+        "State": {
+            "enum": [
+                "Enabled",
+                "Disabled",
+                "StandbyOffline",
+                "StandbySpare",
+                "InTest",
+                "Starting",
+                "Absent",
+                "UnavailableOffline",
+                "Deferring",
+                "Quiesced",
+                "Updating"
+            ],
+            "enumDescriptions": {
+                "Absent": "This function or resource is not present or not detected.",
+                "Deferring": "The element will not process any commands but will queue new requests.",
+                "Disabled": "This function or resource has been disabled.",
+                "Enabled": "This function or resource has been enabled.",
+                "InTest": "This function or resource is undergoing testing.",
+                "Quiesced": "The element is enabled but only processes a restricted set of commands.",
+                "StandbyOffline": "This function or resource is enabled, but awaiting an external action to activate it.",
+                "StandbySpare": "This function or resource is part of a redundancy set and is awaiting a failover or other external action to activate it.",
+                "Starting": "This function or resource is starting.",
+                "UnavailableOffline": "This function or resource is present but cannot be used.",
+                "Updating": "The element is updating and may be unavailable or degraded."
+            },
+            "type": "string"
+        },
+        "Status": {
+            "additionalProperties": false,
+            "description": "This type describes the status and health of a resource and its children.",
+            "longDescription": "This type shall contain any status or health properties of a resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Health": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Health"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "This represents the health state of this resource in the absence of its dependent resources.",
+                    "longDescription": "This property shall represent the HealthState of the resource without considering its dependent resources. The values shall conform to those defined in the Redfish specification.",
+                    "readonly": true
+                },
+                "HealthRollup": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Health"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "This represents the overall health state from the view of this resource.",
+                    "longDescription": "This property shall represent the HealthState of the resource and its dependent resources.  The values shall conform to those defined in the Redfish specification.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem"
+                },
+                "State": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/State"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "This indicates the known state of the resource, such as if it is enabled.",
+                    "longDescription": "This property shall represent if this component is available or not and why.  Enabled indicates the resource is available.  Disabled indicates the resource has been intentionally made unavailable but it can be enabled.  Offline indicates the resource is unavailable intentionally and requires action to be made available.  InTest indicates that the component is undergoing testing.  Starting indicates that the resource is on its way to becoming available.  Absent indicates the resources is physically unavailable.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "UUID": {
+            "pattern": "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "title": "#Resource"
+}

--- a/doc-generator/tests/samples/fragments/json-schema/Resource.v1_6_0.json
+++ b/doc-generator/tests/samples/fragments/json-schema/Resource.v1_6_0.json
@@ -1,0 +1,912 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_3_0.json",
+    "copyright": "Copyright 2014-2017 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "DurableNameFormat": {
+            "enum": [
+                "NAA",
+                "iQN",
+                "FC_WWN",
+                "UUID",
+                "EUI",
+                "NQN",
+                "NSID"
+            ],
+            "enumDescriptions": {
+                "EUI": "IEEE-defined 64-bit Extended Unique Identifier.",
+                "FC_WWN": "Fibre Channel World Wide Name.",
+                "NAA": "Name Address Authority Format.",
+                "NQN": "NVMe Qualified Name.",
+                "NSID": "NVM Namespace Identifier.",
+                "UUID": "Universally Unique Identifier.",
+                "iQN": "iSCSI Qualified Name."
+            },
+            "enumLongDescriptions": {
+                "EUI": "This durable name shall be the hexadecimal representation of the IEEE-defined 64-bit Extended Unique Identifier as defined in the IEEE's Guidelines for 64-bit Global Identifier (EUI-64) Specification.",
+                "FC_WWN": "This durable name shall be a hexadecimal representation of the World Wide Name format as defined in the T11 Fibre Channel Physical and Signaling Interface Specification.",
+                "NAA": "This durable name shall be a hexadecimal representation of the Name Address Authority structure as defined in the T11 Fibre Channel - Framing and Signaling - 3 (FC-FS-3) specification.",
+                "NQN": "This durable name shall be in the NVMe Qualified Name format as defined in the NVN Express over Fabric Specification.",
+                "NSID": "This durable name shall be in the NVM Namespace Identifier format as defined in the NVN Express Specification.",
+                "UUID": "This durable name shall be the hexadecimal representation of the Universal Unique Identifier as defined in the Internation Telecom Union's OSI networking and system aspects - Naming, Addressing and Registration Specification.",
+                "iQN": "This durable name shall be in the iSCSI Qualified Name format as defined in RFC 3720 and RFC 3721."
+            },
+            "type": "string"
+        },
+        "Identifier": {
+            "additionalProperties": false,
+            "description": "This type describes any additional identifiers for a resource.",
+            "longDescription": "This type shall contain any additional identifiers of a resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DurableName": {
+                    "description": "This indicates the world wide, persistent name of the resource.",
+                    "longDescription": "This property shall contain the world wide unique identifier for the resource. The string shall be in the format described by the value of the Identifier.DurableNameFormat property.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "DurableNameFormat": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DurableNameFormat"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "This represents the format of the DurableName property.",
+                    "longDescription": "This property shall represent the format of the DurableName property.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "IndicatorLED": {
+            "deprecated": "This definition has been moved to the unversioned namespace so that external references can pick up changes over time.",
+            "enum": [
+                "Lit",
+                "Blinking",
+                "Off"
+            ],
+            "enumDescriptions": {
+                "Blinking": "The Indicator LED is blinking.",
+                "Lit": "The Indicator LED is lit.",
+                "Off": "The Indicator LED is off."
+            },
+            "enumLongDescriptions": {
+                "Blinking": "This value shall represent the Indicator LED is in a blinking state where the LED is being turned on and off in repetition.  If this value is not supported by the service, the service shall reject PATCH or PUT requests containing this value by returning HTTP 400 (Bad Request).",
+                "Lit": "This value shall represent the Indicator LED is in a solid on state.  If this value is not supported by the service, the service shall reject PATCH or PUT requests containing this value by returning HTTP 400 (Bad Request).",
+                "Off": "This value shall represent the Indicator LED is in a solid off state.  If this value is not supported by the service, the service shall reject PATCH or PUT requests containing this value by returning HTTP 400 (Bad Request)."
+            },
+            "type": "string"
+        },
+        "Location": {
+            "additionalProperties": false,
+            "description": "This type describes the location of a resource.",
+            "longDescription": "This type shall describe the location of a resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AltitudeMeters": {
+                    "description": "The altitude of the resource in meters.",
+                    "longDescription": "The altitude of the resource in meters.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "m"
+                },
+                "Info": {
+                    "deprecated": "This property has been Deprecated in favor of new properties defined in Resource.v1_3_0.Location and Resource.v1_5_0.Location.",
+                    "description": "This indicates the location of the resource.",
+                    "longDescription": "This property shall represent the location of the resource.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "InfoFormat": {
+                    "deprecated": "This property has been Deprecated in favor of new properties defined in Resource.v1_3_0.Location and Resource.v1_5_0.Location.",
+                    "description": "This represents the format of the Info property.",
+                    "longDescription": "This property shall represent the format of the Info property.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Latitude": {
+                    "description": "The latitude resource.",
+                    "longDescription": "The value shall be the latitude of the resource specified in degrees using a decimal format and not minutes or seconds.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "deg"
+                },
+                "Longitude": {
+                    "description": "The longitude resource in degrees.",
+                    "longDescription": "The value shall be the longitude of the resource specified in degrees using a decimal format and not minutes or seconds.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "deg"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem"
+                },
+                "PartLocation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PartLocation"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Postal address of the addressed resource.",
+                    "longDescription": "The value shall be a postal address of the resource."
+                },
+                "Placement": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Placement"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "A place within the addressed location.",
+                    "longDescription": "The value shall be a place within the addressed location."
+                },
+                "PostalAddress": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/PostalAddress"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Postal address of the addressed resource.",
+                    "longDescription": "The value shall be a postal address of the resource."
+                }
+            },
+            "type": "object"
+        },
+        "LocationType": {
+            "description": "Defines the location types for PartLocation.",
+            "enum": [
+                "Slot",
+                "Bay",
+                "Connector",
+                "Socket"
+            ],
+            "enumDescriptions": {
+                "Bay": "Defines a bay as the type of location.",
+                "Connector": "Defines a connector as the type of location.",
+                "Slot": "Defines a slot as the type of location.",
+                "Socket": "Defines a socket as the type of location."
+            },
+            "enumLongDescriptions": {
+                "Bay": "Bay shall be used to indicate the type of PartLocation is of type bay.",
+                "Connector": "Connector shall be used to indicate the type of PartLocation is of type connector.",
+                "Slot": "Slot shall be used to indicate the type of PartLocation is of type slot.",
+                "Socket": "Socket shall be used to indicate the type of PartLocation is of type socket."
+            },
+            "longDescription": "Enumeration literals shall name the type of location in use.",
+            "type": "string"
+        },
+        "Orientation": {
+            "description": "Defines a orientation for the ordering of the ordinal value of the part location.",
+            "enum": [
+                "FrontToBack",
+                "BackToFront",
+                "TopToBottom",
+                "BottomToTop",
+                "LeftToRight",
+                "RightToLeft"
+            ],
+            "enumDescriptions": {
+                "BackToFront": "Defines the ordering for the LocationOrdinalValue is back to front.",
+                "BottomToTop": "Defines the ordering for the LocationOrdinalValue is bottom to top.",
+                "FrontToBack": "Defines the ordering for the LocationOrdinalValue is front to back.",
+                "LeftToRight": "Defines the ordering for the LocationOrdinalValue is left to right.",
+                "RightToLeft": "Defines the ordering for the LocationOrdinalValue is right to left.",
+                "TopToBottom": "Defines the ordering for the LocationOrdinalValue is top to bottom."
+            },
+            "enumLongDescriptions": {
+                "BackToFront": "This value shall be used to specify the ordering for LocationOrdinalValue is back to front.",
+                "BottomToTop": "This value shall be used to specify the ordering for LocationOrdinalValue is bottom to top.",
+                "FrontToBack": "This value shall be used to specify the ordering for LocationOrdinalValue is front to back.",
+                "LeftToRight": "This value shall be used to specify the ordering for LocationOrdinalValue is left to right.",
+                "RightToLeft": "This value shall be used to specify the ordering for LocationOrdinalValue is right to left.",
+                "TopToBottom": "This value shall be used to specify the ordering for LocationOrdinalValue is top to bottom."
+            },
+            "longDescription": "Enumeration literals shall name the orientation for the location type ordering in determining the LocationOrdinalValue.",
+            "type": "string"
+        },
+        "PartLocation": {
+            "additionalProperties": false,
+            "description": "The part location within the placement.",
+            "longDescription": "The value shall describe a location within a resource.  This representation shall be used to indicate the location within the Placement.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LocationOrdinalValue": {
+                    "description": "The number that represents the location of the part.  If LocationType is slot and this unit is in slot 2 then the LocationOrdinalValue will be 2.",
+                    "longDescription": "The value shall be the number that represents the location of the part based on the LocationType.  LocationOrdinalValue shall be measured based on the Orientation value starting with 0.",
+                    "readonly": true,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "LocationType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LocationType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of location of the part, such as slot, bay, socket and slot.",
+                    "longDescription": "The value shall be a LocationType enumeration literal indicating the type of rack units in use.",
+                    "readonly": true
+                },
+                "Orientation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Orientation"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The orientation for the ordering of the slot enumeration used by the LocationOrdinalValue property.",
+                    "longDescription": "The value shall be a Orientation enumeration literal indicating the orientation for the ordering used by the LocationOrdinalValue property.",
+                    "readonly": true
+                },
+                "Reference": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The reference point for the part location.  This is used to give guidance as to the general location of the part.",
+                    "longDescription": "The value shall be a Reference enumeration literal indicating the general location within the unit of the part.",
+                    "readonly": true
+                },
+                "ServiceLabel": {
+                    "description": "This is the label of the part location, such as a silk screened name or a printed label.",
+                    "longDescription": "The value shall be the label assigned for service at the part location.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Placement": {
+            "additionalProperties": false,
+            "description": "The placement within the addressed location.",
+            "longDescription": "The value shall describe a location within a resource.  Examples include a shelf in a rack.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Rack": {
+                    "description": "Name of a rack location within a row.",
+                    "longDescription": "The value shall be the name of the rack within a row.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RackOffset": {
+                    "description": "Vertical location of the item in terms of RackOffsetUnits.",
+                    "longDescription": "Vertical location of the item in the rack. Rack offset units shall be measured from bottom to top starting with 0.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "RackOffsetUnits": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RackUnits"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of Rack Units in use.",
+                    "longDescription": "The value shall be a RackUnit enumeration literal indicating the type of rack units in use.",
+                    "readonly": false
+                },
+                "Row": {
+                    "description": "Name of row.",
+                    "longDescription": "The value shall be the name of the row.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "PostalAddress": {
+            "additionalProperties": false,
+            "description": "The PostalAddress for a resource.",
+            "longDescription": "Instances shall describe a postal address for a resource. For more information see RFC5139. Depending on use, the instance may represent a past, current, or future location.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AdditionalCode": {
+                    "description": "Additional code.",
+                    "longDescription": "The value shall conform the requirements of the ADDCODE field as defined in RFC5139.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Building": {
+                    "description": "Name of the building.",
+                    "longDescription": "The value shall conform the requirements of the BLD field as defined in RFC5139.  The value shall be name a building used to locate the resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "City": {
+                    "description": "City, township, or shi (JP).",
+                    "longDescription": "The value shall conform the requirements of the A3 field as defined in RFC5139.  It is used to name a city, township, or shi (JP).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Community": {
+                    "description": "Postal community name.",
+                    "longDescription": "The value shall conform the requirements of the PCN field as defined in RFC5139.  The value shall be a postal community name.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Country": {
+                    "description": "Country.",
+                    "longDescription": "The value shall conform the requirements of the Country field as defined in RFC5139.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "District": {
+                    "description": "A county, parish, gun (JP), or  district (IN).",
+                    "longDescription": "The value shall conform the requirements of the A2 field as defined in RFC5139.  It is used to name a county, parish, gun (JP), or  district (IN).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Division": {
+                    "description": "City division, borough, dity district, ward, chou (JP).",
+                    "longDescription": "The value shall conform the requirements of the A4 field as defined in RFC5139.  It is used to name a city division, borough, dity district, ward, chou (JP).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Floor": {
+                    "description": "Floor.",
+                    "longDescription": "The value shall conform the requirements of the FLR field as defined in RFC5139.  It is used to provide a floor designation.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "GPSCoords": {
+                    "deprecated": "This property has been Deprecated in favor of Location.v1_6_0.Longitude and Location.v1_6_0.Latitude",
+                    "description": "The GPS coordinates of the part.",
+                    "longDescription": "The value shall conform the requirements of the ADDCODE field as defined in RFC5139. The value shall be the GPS coordinates of the location. If furnished, this shall be expressed in the format '[-][nn]n.nnnnnn, [-][nn]n.nnnnn', i.e. two numbers, either positive or negative, with six decimal places of precision, comma-separated.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "HouseNumber": {
+                    "description": "Numeric portion of house number.",
+                    "longDescription": "The value shall conform the requirements of the HNO field as defined in RFC5139.  It is the numeric portion of the house number.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "HouseNumberSuffix": {
+                    "description": "House number suffix.",
+                    "longDescription": "The value shall conform the requirements of the HNS field as defined in RFC5139.  It is used to provide a suffix to a house number, (F, B, 1/2).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Landmark": {
+                    "description": "Landmark.",
+                    "longDescription": "The value shall conform the requirements of the LMK field as defined in RFC5139.  It is used to identify a landmark or vanity address.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "LeadingStreetDirection": {
+                    "description": "A leading street direction.",
+                    "longDescription": "The value shall conform the requirements of the PRD field as defined in RFC5139.  It is used to name a leading street direction, (N, W, SE).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Location": {
+                    "description": "Room designation or other additional info.",
+                    "longDescription": "The value shall conform the requirements of the LOC field as defined in RFC5139.  It is used to provide additional information.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "description": "Name.",
+                    "longDescription": "The value shall conform the requirements of the NAM field as defined in RFC5139.  It is used to name the occupant.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Neighborhood": {
+                    "description": "Neighborhood or block.",
+                    "longDescription": "The value shall conform the requirements of the A5 field as defined in RFC5139.  It is used to name a neighborhood or block.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "POBox": {
+                    "description": "Post office box (P.O. box).",
+                    "longDescription": "The value shall conform the requirements of the POBOX field as defined in RFC5139.  The value shall be a Post office box (P.O. box).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PlaceType": {
+                    "description": "A description of the type of place that is addressed.",
+                    "longDescription": "The value shall conform the requirements of the PLC field as defined in RFC5139.  Examples include: office, residence,...).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "PostalCode": {
+                    "description": "Postal code (or zip code).",
+                    "longDescription": "The value shall conform the requirements of the PC field as defined in RFC5139. The value shall be a Postal code (or zip code).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Road": {
+                    "description": "A primary road or street.",
+                    "longDescription": "The value shall conform the requirements of the RD field as defined in RFC5139.  The value designates a primary road or street.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RoadBranch": {
+                    "description": "Road branch.",
+                    "longDescription": "The value shall conform the requirements of the RDBR field as defined in RFC5139.  The value shall be a Post office box (P.O. box)road branch.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RoadPostModifier": {
+                    "description": "Road post-modifier.",
+                    "longDescription": "The value shall conform the requirements of the POM field as defined in RFC5139.  (Extended).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RoadPreModifier": {
+                    "description": "Road pre-modifier.",
+                    "longDescription": "The value shall conform the requirements of the PRM field as defined in RFC5139.  (Old, New).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RoadSection": {
+                    "description": "Road Section.",
+                    "longDescription": "The value shall conform the requirements of the RDSEC field as defined in RFC5139.  The value shall be a road section.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "RoadSubBranch": {
+                    "description": "Road sub branch.",
+                    "longDescription": "The value shall conform the requirements of the RDSUBBR field as defined in RFC5139.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Room": {
+                    "description": "Name or number of the room.",
+                    "longDescription": "The value shall conform the requirements of the ROOM field as defined in RFC5139.  The value shall be a name or number of a room used to locate the resource within the unit.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Seat": {
+                    "description": "Seat (desk, cubicle, workstation).",
+                    "longDescription": "The value shall conform the requirements of the SEAT field as defined in RFC5139.  The value shall be a name or number of a Seat (desk, cubicle, workstation).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Street": {
+                    "description": "Street name.",
+                    "longDescription": "The value shall conform the requirements of the A6 field as defined in RFC5139.  It is used to name a street.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "StreetSuffix": {
+                    "description": "Avenue, Platz, Street, Circle.",
+                    "longDescription": "The value shall conform the requirements of the STS field as defined in RFC5139.  It is used to name a  street suffix.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Territory": {
+                    "description": "A top-level subdivision within a country.",
+                    "longDescription": "The value shall conform the requirements of the A1 field as defined in RFC5139 when used to name a territory, state, region, province, or prefecture within a country.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "TrailingStreetSuffix": {
+                    "description": "A trailing street suffix.",
+                    "longDescription": "The value shall conform the requirements of the POD field as defined in RFC5139.  It is used to name a trailing street suffix.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Unit": {
+                    "description": "Name or number of the unit (apartment, suite).",
+                    "longDescription": "The value shall conform the requirements of the UNIT field as defined in RFC5139.  The value shall be a name or number of a unit (apartment, suite) used to locate the resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "PowerState": {
+            "deprecated": "This definition has been moved to the unversioned namespace so that external references can pick up changes over time.",
+            "enum": [
+                "On",
+                "Off",
+                "PoweringOn",
+                "PoweringOff"
+            ],
+            "enumDescriptions": {
+                "Off": "The state is powered Off.",
+                "On": "The state is powered On.",
+                "PoweringOff": "A temporary state between On and Off.",
+                "PoweringOn": "A temporary state between Off and On."
+            },
+            "type": "string"
+        },
+        "RackUnits": {
+            "description": "Defines a rack unit.",
+            "enum": [
+                "OpenU",
+                "EIA_310"
+            ],
+            "enumDescriptions": {
+                "EIA_310": "Defines a rack unit as being equal to 1.75 in (44.45 mm).",
+                "OpenU": "Defines a rack unit as being equal to 48 mm (1.89 in)."
+            },
+            "enumLongDescriptions": {
+                "EIA_310": "Rack units shall be specified as defined by the EIA-310 standard.",
+                "OpenU": "Rack units shall be specifie3d in terms of the Open Compute Open Rack specification."
+            },
+            "longDescription": "Enumeration literals shall name the type of rack units in use.",
+            "type": "string"
+        },
+        "Reference": {
+            "description": "Defines a reference area for the location of the part.",
+            "enum": [
+                "Top",
+                "Bottom",
+                "Front",
+                "Rear",
+                "Left",
+                "Right",
+                "Middle"
+            ],
+            "enumDescriptions": {
+                "Bottom": "Defines the part as being in the bottom of the unit.",
+                "Front": "Defines the part as being in the front of the unit.",
+                "Left": "Defines the part as being in the left of the unit.",
+                "Middle": "Defines the part as being in the middle of the unit.",
+                "Rear": "Defines the part as being in the rear of the unit.",
+                "Right": "Defines the part as being in the right of the unit.",
+                "Top": "Defines the part as being in the top of the unit."
+            },
+            "enumLongDescriptions": {
+                "Bottom": "Top shall be used to specify the part location is in the bottom of the unit.",
+                "Front": "Top shall be used to specify the part location is in the front of the unit.",
+                "Left": "Top shall be used to specify the part location is in the left of the unit.",
+                "Middle": "Top shall be used to specify the part location is in the middle of the unit.",
+                "Rear": "Top shall be used to specify the part location is in the rear of the unit.",
+                "Right": "Top shall be used to specify the part location is in the right of the unit.",
+                "Top": "Top shall be used to specify the part location is in the top of the unit."
+            },
+            "longDescription": "Enumeration literals shall name the reference for the part location.",
+            "type": "string"
+        },
+        "ReferenceableMember": {
+            "additionalProperties": false,
+            "description": "This is the base type for addressable members of an array.",
+            "longDescription": "Array members can be referenced using the value returned in the @odata.id property which may or may not be a dereferenceable URL. The @odata.id of this entity shall be the location of this element within an Item.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MemberId": {
+                    "description": "This is the identifier for the member within the collection.",
+                    "longDescription": "The value of this string shall uniquely identify the member within the collection.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections.",
+                    "longDescription": "The value of this string shall be of the format for the reserved word *Oem*."
+                }
+            },
+            "type": "object"
+        },
+        "Resource": {
+            "additionalProperties": false,
+            "description": "This is the base type for resources and referenceable members.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/context"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/type"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections.",
+                    "longDescription": "The value of this string shall be of the format for the reserved word *Oem*."
+                }
+            },
+            "required": [
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ResourceCollection": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message|Privileges)\\.[a-zA-Z_][a-zA-Z0-9_.]+$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/context"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata.v4_0_1.json#/definitions/type"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "This is the manufacturer/provider specific extension moniker used to divide the Oem object into sections.",
+                    "longDescription": "The value of this string shall be of the format for the reserved word *Oem*."
+                }
+            },
+            "type": "object"
+        }
+    },
+    "title": "#Resource.v1_6_0"
+}

--- a/doc-generator/tests/samples/fragments/json-schema/odata.v4_0_1.json
+++ b/doc-generator/tests/samples/fragments/json-schema/odata.v4_0_1.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_3_0.json",
+    "definitions": {
+        "context": {
+            "type": "string",
+            "format": "uri",
+            "readonly": true,
+            "description": "The OData description of a payload.",
+            "longDescription": "The value of this property shall be the context URL that describes the resource according to OData-Protocol and shall be of the form defined in the Redfish specification."
+        },
+        "id": {
+            "type": "string",
+            "format": "uri",
+            "readonly": true,
+            "description": "The unique identifier for a resource.",
+            "longDescription": "The value of this property shall be the unique identifier for the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "idRef": {
+            "type": "object",
+            "properties": {
+                "@odata.id": {
+                    "$ref": "#/definitions/id"
+                }
+            },
+            "additionalProperties": false,
+            "description": "A reference to a resource.",
+            "longDescription": "The value of this property shall be used for references to a resource."
+        },
+        "type": {
+            "type": "string",
+            "readonly": true,
+            "description": "The type of a resource.",
+            "longDescription": "The value of this property shall be an absolute URL that specifies the type of the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "count": {
+            "type": "number",
+            "readonly": true,
+            "description": "The number of items in a collection.",
+            "longDescription": "The value of this property shall be an integer representing the number of items in a collection."
+        }
+    }
+}

--- a/doc-generator/tests/samples/fragments/json-schema/odata.v4_0_2.json
+++ b/doc-generator/tests/samples/fragments/json-schema/odata.v4_0_2.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_3_0.json",
+    "definitions": {
+        "context": {
+            "type": "string",
+            "format": "uri",
+            "readonly": true,
+            "description": "The OData description of a payload.",
+            "longDescription": "The value of this property shall be the context URL that describes the resource according to OData-Protocol and shall be of the form defined in the Redfish specification."
+        },
+        "id": {
+            "type": "string",
+            "format": "uri",
+            "readonly": true,
+            "description": "The unique identifier for a resource.",
+            "longDescription": "The value of this property shall be the unique identifier for the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "idRef": {
+            "type": "object",
+            "properties": {
+                "@odata.id": {
+                    "$ref": "#/definitions/id"
+                }
+            },
+            "additionalProperties": false,
+            "description": "A reference to a resource.",
+            "longDescription": "The value of this property shall be used for references to a resource."
+        },
+        "type": {
+            "type": "string",
+            "readonly": true,
+            "description": "The type of a resource.",
+            "longDescription": "The value of this property shall be an absolute URL that specifies the type of the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "count": {
+            "type": "number",
+            "readonly": true,
+            "description": "The number of items in a collection.",
+            "longDescription": "The value of this property shall be an integer representing the number of items in a collection."
+        },
+        "etag": {
+            "type": "string",
+            "readonly": true,
+            "description": "The current ETag of the resource.",
+            "longDescription": "The value of this property shall be a string that is defined by the ETag HTTP header definition in RFC7232."
+        }
+    }
+}

--- a/doc-generator/tests/samples/fragments/json-schema/odata.v4_0_3.json
+++ b/doc-generator/tests/samples/fragments/json-schema/odata.v4_0_3.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema.v1_4_0.json",
+    "definitions": {
+        "context": {
+            "type": "string",
+            "format": "uri",
+            "readonly": true,
+            "description": "The OData description of a payload.",
+            "longDescription": "The value of this property shall be the context URL that describes the resource according to OData-Protocol and shall be of the form defined in the Redfish specification."
+        },
+        "id": {
+            "type": "string",
+            "format": "uri",
+            "readonly": true,
+            "description": "The unique identifier for a resource.",
+            "longDescription": "The value of this property shall be the unique identifier for the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "idRef": {
+            "type": "object",
+            "properties": {
+                "@odata.id": {
+                    "$ref": "#/definitions/id"
+                }
+            },
+            "additionalProperties": false,
+            "description": "A reference to a resource.",
+            "longDescription": "The value of this property shall be used for references to a resource."
+        },
+        "type": {
+            "type": "string",
+            "readonly": true,
+            "description": "The type of a resource.",
+            "longDescription": "The value of this property shall be a URI fragment that specifies the type of the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "count": {
+            "type": "integer",
+            "readonly": true,
+            "description": "The number of items in a collection.",
+            "longDescription": "The value of this property shall be an integer representing the number of items in a collection."
+        },
+        "etag": {
+            "type": "string",
+            "readonly": true,
+            "description": "The current ETag of the resource.",
+            "longDescription": "The value of this property shall be a string that is defined by the ETag HTTP header definition in RFC7232."
+        },
+        "nextLink": {
+            "type": "string",
+            "format": "uri",
+            "readonly": true,
+            "description": "The URI to the resource containing the next set of partial members.",
+            "longDescription": "The value of this property shall be a URI to a resource, with the same @odata.type, containing the next set of partial members."
+        }
+    }
+}

--- a/doc-generator/tests/test_fragments.py
+++ b/doc-generator/tests/test_fragments.py
@@ -1,0 +1,90 @@
+# Copyright Notice:
+# Copyright 2021 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tools/blob/master/LICENSE.md
+
+"""
+File: test_fragments.py
+
+Brief: Tests that exercise doc generation for "fragments."
+"""
+
+import os
+import copy
+from unittest.mock import patch
+import pytest
+from doc_generator import DocGenerator
+
+testcase_path = os.path.join('tests', 'samples', 'fragments')
+fragment_path = os.path.join(testcase_path, 'CommonPropertySchema.json#/definitions/CommonProperties/properties');
+
+base_config = {
+    'excluded_by_match': ['@odata.count', '@odata.navigationLink'],
+    'profile_resources': {},
+    'units_translation': {},
+    'excluded_annotations_by_match': ['@odata.count', '@odata.navigationLink'],
+    'excluded_schemas': [],
+    'excluded_properties': ['@odata.id', '@odata.context', '@odata.type'],
+    'schema_link_replacements': {},
+
+    'profile': {},
+    'escape_chars': [],
+}
+
+base_config['intro_content'] = "# FRAGMENT FOLLOWS\n\n#include_fragment " + fragment_path + "\n"
+
+
+@patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
+def test_html_output(mockRequest):
+
+    config = copy.deepcopy(base_config)
+    config['output_format'] = 'html'
+
+    input_dir = os.path.join(testcase_path, 'json-schema')
+
+    config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
+    config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
+
+    expected_output = open(os.path.join(testcase_path, 'expected_output.html')).read()
+
+    docGen = DocGenerator([ input_dir ], '/dev/null', config)
+    output = docGen.generate_docs()
+
+    assert expected_output in output
+
+
+@patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
+def test_slate_output(mockRequest):
+
+    config = copy.deepcopy(base_config)
+    config['output_format'] = 'slate'
+
+    input_dir = os.path.join(testcase_path, 'json-schema')
+
+    config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
+    config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
+
+    expected_output = open(os.path.join(testcase_path, 'expected_slate_output.md')).read()
+
+    docGen = DocGenerator([ input_dir ], '/dev/null', config)
+    output = docGen.generate_docs()
+
+    assert expected_output in output
+
+
+@patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
+def test_markdown_output(mockRequest):
+
+    config = copy.deepcopy(base_config)
+    config['output_format'] = 'markdown'
+
+    input_dir = os.path.join(testcase_path, 'json-schema')
+
+    config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
+    config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
+
+    expected_output = open(os.path.join(testcase_path, 'expected_output.md')).read()
+
+    docGen = DocGenerator([ input_dir ], '/dev/null', config)
+    output = docGen.generate_docs()
+
+    assert expected_output in output


### PR DESCRIPTION
Markdown mode fragments were coming out slate-style, as it's the default if
output_format is not specified.