### PR TITLE
Added non-printable space for URI line wrapping

### DIFF
--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -222,7 +222,7 @@ class DocFormatter:
             if part.startswith('{') and part.endswith('}'):
                 part = self.formatter.italic(part)
             uri_parts_highlighted.append(part)
-        uri_highlighted = '/'.join(uri_parts_highlighted)
+        uri_highlighted = '/&#8203;'.join(uri_parts_highlighted)
         return uri_highlighted
 
 


### PR DESCRIPTION
Adding a non-printable whitespace/break character between all URI segments in the output to allow for document conversion tools to better process line wrapping on long URIs.  This occurs primarily in the Resource Collection URI section as the URIs are in a two-column table.