### PR TITLE
Doc generator: accept and use payload provided via content supplement even if a payload directory is in use.

### DIFF
--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -523,11 +523,11 @@ class DocFormatter:
                 payload_key = DocGenUtilities.get_payload_name(schema_name, version)
                 payload = self.config['payloads'].get(payload_key)
                 if payload:
-                    json_payload = '```json\n' + payload.strip() + '\n```\n'
+                    json_payload = payload
                 else:
                     if self.config.get('warn_missing_payloads'):
                         warnings.warn("MISSING JSON PAYLOAD FOR SCHEMA '%(schema_name)s'." %{'schema_name': schema_name})
-            else:
+            if not json_payload and supplemental.get('jsonpayload'):
                 json_payload = supplemental.get('jsonpayload')
 
             definitions = details['definitions']
@@ -777,7 +777,9 @@ class DocFormatter:
                     ref_id += '_v' + version
 
                 cp_gen.add_section(prop_name, ref_id, schema_ref)
-                cp_gen.add_json_payload(supplemental.get('jsonpayload'))
+                if supplemental.get('jsonpayload'):
+                    payload = supplemental.get('jsonpayload')
+                    cp_gen.add_json_payload(payload)
 
                 # Override with supplemental schema description, if provided
                 # If there is a supplemental "description" or "intro", it replaces
@@ -1534,7 +1536,7 @@ class DocFormatter:
                 payload_key = DocGenUtilities.get_payload_name(prop_info['_schema_name'], version, short_name, 'request-example')
                 payload = self.config['payloads'].get(payload_key)
                 if payload:
-                    json_payload = '```json\n' + payload.strip() + '\n```\n'
+                    json_payload = payload
                     heading = self.formatter.para(self.formatter.bold(_("Request Example")))
                     request_payload = heading + self.format_json_payload(json_payload)
                 else:
@@ -1547,7 +1549,7 @@ class DocFormatter:
                 payload_key = DocGenUtilities.get_payload_name(prop_info['_schema_name'], version, short_name, 'response-example')
                 payload = self.config['payloads'].get(payload_key)
                 if payload:
-                    json_payload = '```json\n' + payload.strip() + '\n```\n'
+                    json_payload = payload
                     heading = self.formatter.para(self.formatter.bold(_("Response Example")))
                     response_payload = heading + self.format_json_payload(json_payload)
                 else:
@@ -1559,7 +1561,7 @@ class DocFormatter:
                 payload_key = DocGenUtilities.get_payload_name(prop_info['_schema_name'], version, short_name)
                 payload = self.config['payloads'].get(payload_key)
                 if payload:
-                    json_payload = '```json\n' + payload.strip() + '\n```\n'
+                    json_payload = payload
                     heading = self.formatter.para(self.formatter.bold(_("Example")))
                     example_payload = heading + self.format_json_payload(json_payload) + action_details
 

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -1008,6 +1008,9 @@ pre.code{
 
     def format_json_payload(self, json_payload):
         """ Format a json payload for output. """
+        # Add markdown for formatting. Conditional because some inputs may provide it.
+        if '```json' not in json_payload:
+            json_payload = '```json\n' + json_payload.strip() + '\n```\n'
         return ('<div class="json-payload">' +
                     self.formatter.markdown_to_html(json_payload) + '</div>')
 

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -928,6 +928,9 @@ search: true
 
     def format_json_payload(self, json_payload):
         """ Format a json payload for output. """
+        # Add markdown for formatting. Conditional because some inputs may provide it.
+        if '```json' not in json_payload:
+            json_payload = '```json\n' + json_payload.strip() + '\n```\n'
         return '\n' + json_payload + '\n'
 
 

--- a/doc-generator/tests/test_supplement_output.py
+++ b/doc-generator/tests/test_supplement_output.py
@@ -83,11 +83,15 @@ def test_supplement_output_html (mockRequest):
     # These assertions target strings the supplement provided:
     assert len(status_section) == 1 and 'SUPPLEMENT-SUPPLIED DESCRIPTION for Status' in status_section[0], "Referenced Object (Status) output is missing supplement-supplied description"
     assert len(status_section) == 1 and 'SUPPLEMENT-SUPPLIED INTRO for Status' in status_section[0], "Referenced Object (Status) output is missing supplement-supplied intro"
-    assert len(status_section) == 1 and 'SUPPLEMENT-SUPPLIED JSON for Status' in status_section[0], "Referenced Object (Status) output is missing supplement-supplied json payload"
+    # strip tags from output sections for json payload tests; code highlighting is decorating the
+    # plain-text strings in a way I don't want to rely on.
+    assert len(status_section) == 1 and 'SUPPLEMENT-SUPPLIED JSON for Status' in simple_strip_tags(status_section[0]), "Referenced Object (Status) output is missing supplement-supplied json payload"
 
     assert len(endpoint_section) == 1 and 'SUPPLEMENT-SUPPLIED DESCRIPTION for Endpoint' in endpoint_section[0], "Schema Object (Endpoint) output is missing supplement-supplied description"
     assert len(endpoint_section) == 1 and 'SUPPLEMENT-SUPPLIED INTRO for Endpoint' in endpoint_section[0], "Schema Object (Endpoint) output is missing supplement-supplied intro"
-    assert len(endpoint_section) == 1 and 'SUPPLEMENT-SUPPLIED JSON for Endpoint' in endpoint_section[0], "Schema Object (Endpoint) output is missing supplement-supplied json payload"
+    # strip tags from output sections for json payload tests; code highlighting is decorating the
+    # plain-text strings in a way I don't want to rely on.
+    assert len(endpoint_section) == 1 and 'SUPPLEMENT-SUPPLIED JSON for Endpoint' in simple_strip_tags(endpoint_section[0]), "Schema Object (Endpoint) output is missing supplement-supplied json payload"
 
 
     oem_failed_overrides = [x for x in oem_rows if "This is a description override for the Oem object." not in x]
@@ -297,3 +301,23 @@ def test_supplement_output_from_files_with_action_details (mockRequest):
         ]
     for es in expected_strings:
         assert es in output
+
+
+def simple_strip_tags(s):
+    """ Quick solution to my need to strip tags from output in a couple of the tests.
+    cf. https://stackoverflow.com/questions/753052/strip-html-from-strings-in-python """
+    tag = False
+    quote = False
+    out = ""
+
+    for c in s:
+        if c == '<' and not quote:
+            tag = True
+        elif c == '>' and not quote:
+            tag = False
+        elif (c == '"' or c == "'") and tag:
+            quote = not quote
+        elif not tag:
+            out = out + c
+
+    return out


### PR DESCRIPTION
This enables users to use the content supplement to provide additional mockups that are not in the payload directory. 

Also, make the decoration of json payloads more consistent; common properties section still assumed the ```json
markup would be part of the provided payload. Now it will be added if not present (for markdown and HTML outputs).