### PR TITLE
Doc generator: fix for crash bug in subset mode

### DIFF
--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -445,7 +445,7 @@ pre.code{
             profile_all_values = (profile_values + profile_min_support_values + profile_parameter_values
                                   + profile_recommended_values)
 
-        if subset_mode:
+        if subset_mode and subset:
             supported_values = subset.get('SupportedValues')
             if supported_values:
                 enum = [x for x in enum if x in supported_values]

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -327,7 +327,7 @@ class MarkdownGenerator(DocFormatter):
             profile_all_values = (profile_values + profile_min_support_values + profile_parameter_values
                                   + profile_recommended_values)
 
-            if subset_mode:
+            if subset_mode and subset:
                 supported_values = subset.get('SupportedValues')
                 if supported_values:
                     enum = [x for x in enum if x in supported_values]


### PR DESCRIPTION
Enum processing incorrectly assumed "subset" would be defined for an enum in subset mode. It's optional (absent means "include all"). 