### PR TITLE
Added alternative method for looking up supplemental info for properties

### DIFF
--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -2409,7 +2409,7 @@ class DocFormatter:
                 for key in ['description', 'jsonpayload', 'property_details', 'action_details']:
                     if md_supp.get(key) and key not in supplemental:
                         supplemental[key] = md_supp[key]
-        else:
+        elif schema_supplement:
             # Look up supplemental info based solely on the schema reference
             # This is to work around the fact that common objects are not cached in the property_data structure
             supplemental = schema_supplement.get(schema_ref, {})

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -2409,6 +2409,15 @@ class DocFormatter:
                 for key in ['description', 'jsonpayload', 'property_details', 'action_details']:
                     if md_supp.get(key) and key not in supplemental:
                         supplemental[key] = md_supp[key]
+        else:
+            # Look up supplemental info based solely on the schema reference
+            # This is to work around the fact that common objects are not cached in the property_data structure
+            supplemental = schema_supplement.get(schema_ref, {})
+            md_supp = schema_md_supplement.get(schema_ref)
+            if md_supp:
+                for key in ['description', 'jsonpayload', 'property_details', 'action_details']:
+                    if md_supp.get(key) and key not in supplemental:
+                        supplemental[key] = md_supp[key]
 
         return supplemental
 


### PR DESCRIPTION
Schema files that do not have resource definitions (like Redundancy) are not mapped the into internal data structures the same way as resource definitions (like ComputerSystem) are. The method `get_supplemental_details` takes a schema reference tag and converts it to schema definitions, but if there is no mapping, then no supplemental info is pulled.

The change here allows a config file to directly specify the schema reference when describing supplemental info. For example, the following will allow the `HealthRollup` property in the common `Status` object to have supplemental text inserted:

```
{
    ...
    "schema_supplement": {
        "ComputerSystem": {
            "property_details": {
                "UUID": "<Additional UUID text>"
            }
        },
        "redfish.dmtf.org/schemas/v1/Resource.json": {
            "property_details": {
                "HealthRollup": "Supplemental HealthRollup info"
            }
        }
    }
}
```