### PR TITLE
Doc-generator - Add detection of deprecated URIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.pyc
 redfish-repo-test/node_modules/
 redfish-repo-test/package-lock.json
+.vs/
+doc-generator/.idea/
+

--- a/doc-generator/README_config_files.md
+++ b/doc-generator/README_config_files.md
@@ -26,6 +26,7 @@ Note that the names of some config keys differ from their command-line counterpa
 - excluded_pattern_properties: pattern properties to omit from output. Note that backslashes must be escaped in JSON ("\" becomes "\\").
 - excluded_properties: A list of property names (strings) to omit. Wildcard match is supported for strings that begin with "*" ("*odata.count" matches "Members\@odata.count" and others).
 - excluded_schemas: Schemas (by name) to omit from output.
+- excluded_schema_uris: Array of strings that if found in each schema URI list, are excluded from the displayed list, with a note added to the list to indicate that some URIs have been omitted.
 - format (command line: `format`): Output format. One of `markdown`, `slate`, `html`, `csv`
 - html_title: A string to use as the `title` element in HTML output.
 - import_from: Name of a file or directory containing JSON schemas to process. Wild cards are acceptable. Default: json-schema.

--- a/doc-generator/doc_formatter/csv_generator.py
+++ b/doc-generator/doc_formatter/csv_generator.py
@@ -288,7 +288,7 @@ class CsvGenerator(DocFormatter):
         pass
 
 
-    def add_uris(self, uris):
+    def add_uris(self, uris, urisDeprecated):
         """ CSV omits URIs """
         pass
 

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -851,6 +851,13 @@ class DocFormatter:
             [preamble, collection_file_name] = x.rsplit('/', 1)
             [collection_name, rest] = collection_file_name.split('.', 1)
             uris = sorted(self.property_data[x].get('uris', []), key=str.lower)
+
+            # append Deprecated text for any deprecated URIs
+            urisDeprecated = self.property_data[x].get('urisDeprecated', [])
+            for i in range(len(uris)):
+                if uris[i] in urisDeprecated:
+                    uris[i] += _(" (deprecated)")
+
             data[collection_name] = uris
         return data
 

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -178,7 +178,7 @@ class DocFormatter:
         raise NotImplementedError
 
 
-    def add_uris(self, uris):
+    def add_uris(self, uris, urisDeprecated):
         """ Add the uris """
         raise NotImplementedError
 
@@ -586,7 +586,7 @@ class DocFormatter:
                 self.add_deprecation_text(details['deprecated'])
 
             if len(uris):
-                self.add_uris(uris)
+                self.add_uris(uris, details['urisDeprecated'])
                 self.current_uris = uris
             else:
                 self.current_uris = []

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -983,15 +983,15 @@ pre.code{
         # if resource block-related URIs are in the list, omit them for brevity
         has_resource_block_uris = False
         for uri in sorted(uris, key=str.lower):
-            if 'ResourceBlocks' in uri:
+            if '{ResourceBlockId}/' in uri:
                 has_resource_block_uris = True
             else:
                 uri_strings.append('<li class="hanging-indent">' + self.format_uri(uri) + '</li>')
 
         # if resource block-related URIs have been trimmed, add a note 
         if has_resource_block_uris:
-            uri_strings.append('<li class="hanging-indent">' +
-                _("* Note: Resource block-related URIs have been omitted from this list") + '\n</li>')
+            uri_strings.append('<li class="hanging-indent">' + "* " +
+                _("Note: Resource block-related URIs have been omitted from this list") + '\n</li>')
 
         uri_block = '<ul class="nobullet">' + '\n'.join(uri_strings) + '</ul>'
         uri_content = '<h4>' + _('URIs:') + '</h4>' + uri_block

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -982,7 +982,7 @@ pre.code{
         
         # exclude URIs from the list for brevity
         has_excluded_uris = False
-        excluded_uris = self.config.get('excluded_schema_uris')
+        excluded_uris = self.config.get('excluded_schema_uris', [])
         for uri in sorted(uris, key=str.lower):
             exclude_this_uri = False
             for xuri in excluded_uris:

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -980,10 +980,10 @@ pre.code{
             if uris[i] in urisDeprecated:
                 uris[i] += _(" (deprecated)")
         
-        # if resource block-related URIs are in the list, omit them for brevity
+        # if resource block-related URIs are in the list, omit them for brevity in non-normative output
         has_resource_block_uris = False
         for uri in sorted(uris, key=str.lower):
-            if '{ResourceBlockId}/' in uri:
+            if (not self.config.get('normative')) and ('{ResourceBlockId}/' in uri):
                 has_resource_block_uris = True
             else:
                 uri_strings.append('<li class="hanging-indent">' + self.format_uri(uri) + '</li>')

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -980,18 +980,22 @@ pre.code{
             if uris[i] in urisDeprecated:
                 uris[i] += _(" (deprecated)")
         
-        # if resource block-related URIs are in the list, omit them for brevity in non-normative output
-        has_resource_block_uris = False
+        # exclude URIs from the list for brevity
+        has_excluded_uris = False
+        excluded_uris = self.config.get('excluded_schema_uris')
         for uri in sorted(uris, key=str.lower):
-            if (not self.config.get('normative')) and ('{ResourceBlockId}/' in uri):
-                has_resource_block_uris = True
-            else:
+            exclude_this_uri = False
+            for xuri in excluded_uris:
+                if xuri in uri:
+                    exclude_this_uri = True
+                    has_excluded_uris = True
+            if not exclude_this_uri:
                 uri_strings.append('<li class="hanging-indent">' + self.format_uri(uri) + '</li>')
 
-        # if resource block-related URIs have been trimmed, add a note 
-        if has_resource_block_uris:
+        # if excluded URIs have been trimmed, add a note 
+        if has_excluded_uris:
             uri_strings.append('<li class="hanging-indent">' + "* " +
-                _("Note: Resource block-related URIs have been omitted from this list") + '\n</li>')
+                _("Note: Some URIs omitted for brevity, refer to schema for the complete list.") + '\n</li>')
 
         uri_block = '<ul class="nobullet">' + '\n'.join(uri_strings) + '</ul>'
         uri_content = '<h4>' + _('URIs:') + '</h4>' + uri_block

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -972,11 +972,26 @@ pre.code{
         self.this_section['deprecation_text'] = depr_text
 
 
-    def add_uris(self, uris):
+    def add_uris(self, uris, urisDeprecated):
         """ Add the URIs (which should be a list) """
         uri_strings = []
+        
+        for i in range(len(uris)):
+            if uris[i] in urisDeprecated:
+                uris[i] += _(" (deprecated)")
+        
+        # if resource block-related URIs are in the list, omit them for brevity
+        has_resource_block_uris = False
         for uri in sorted(uris, key=str.lower):
-            uri_strings.append('<li class="hanging-indent">' + self.format_uri(uri) + '</li>')
+            if 'ResourceBlocks' in uri:
+                has_resource_block_uris = True
+            else:
+                uri_strings.append('<li class="hanging-indent">' + self.format_uri(uri) + '</li>')
+
+        # if resource block-related URIs have been trimmed, add a note 
+        if has_resource_block_uris:
+            uri_strings.append('<li class="hanging-indent">' +
+                _("* Note: Resource block-related URIs have been omitted from this list") + '\n</li>')
 
         uri_block = '<ul class="nobullet">' + '\n'.join(uri_strings) + '</ul>'
         uri_content = '<h4>' + _('URIs:') + '</h4>' + uri_block

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -946,12 +946,11 @@ class MarkdownGenerator(DocFormatter):
 
     def add_uris(self, uris, urisDeprecated):
         """ Add the URIs (which should be a list) """
-        has_excluded_uris = False
-        
+        has_excluded_uris = False    
         uri_block = self.format_head_three(_('URIs'), self.level)
         for uri in sorted(uris, key=str.lower):
             exclude_this_uri = False
-            for xuri in self.config.get('excluded_schema_uris'):
+            for xuri in self.config.get('excluded_schema_uris', []):
                 if xuri in uri:
                     exclude_this_uri = True
                     has_excluded_uris = True

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -946,19 +946,25 @@ class MarkdownGenerator(DocFormatter):
 
     def add_uris(self, uris, urisDeprecated):
         """ Add the URIs (which should be a list) """
-        has_resource_block_uris = False
+        has_excluded_uris = False
+        
         uri_block = self.format_head_three(_('URIs'), self.level)
         for uri in sorted(uris, key=str.lower):
-            if (not self.config.get('normative')) and ('{ResourceBlockId}/' in uri):   # trim out resource block-related URIs
-                has_resource_block_uris = True
+            exclude_this_uri = False
+            for xuri in self.config.get('excluded_schema_uris'):
+                if xuri in uri:
+                    exclude_this_uri = True
+                    has_excluded_uris = True
+            if exclude_this_uri:
                 continue
+            
             if uri in urisDeprecated:
                 uri_block += "\n" + self.format_uri(uri) + _(" (deprecated)") +"<br>"
             else:
                 uri_block += "\n" + self.format_uri(uri) + "<br>"
 
-        if has_resource_block_uris:  # if URIs were trimmed, add a note
-            uri_block += "\n\* " + _("Note: Resource block-related URIs have been omitted from this list") + "<br>"
+        if has_excluded_uris:  # if URIs were trimmed, add a note
+            uri_block += "\n\* " + _("Note: Some URIs omitted for brevity, refer to schema for the complete list.") + "<br>"
             
         self.this_section['uris'] = uri_block + "\n"
 

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -949,7 +949,7 @@ class MarkdownGenerator(DocFormatter):
         has_resource_block_uris = False
         uri_block = self.format_head_three(_('URIs'), self.level)
         for uri in sorted(uris, key=str.lower):
-            if 'ResourceBlocks' in uri:   # trim out resource block-related URIs
+            if '{ResourceBlockId}/' in uri:   # trim out resource block-related URIs
                 has_resource_block_uris = True
                 continue
             if uri in urisDeprecated:
@@ -958,7 +958,7 @@ class MarkdownGenerator(DocFormatter):
                 uri_block += "\n" + self.format_uri(uri) + "<br>"
 
         if has_resource_block_uris:  # if URIs were trimmed, add a note
-            uri_block += "\n" + _("* Note: Resource block-related URIs have been omitted from this list") + "<br>"
+            uri_block += "\n\* " + _("Note: Resource block-related URIs have been omitted from this list") + "<br>"
             
         self.this_section['uris'] = uri_block + "\n"
 

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -944,11 +944,22 @@ class MarkdownGenerator(DocFormatter):
         self.this_section['deprecation_text'] = depr_text + '\n'
 
 
-    def add_uris(self, uris):
+    def add_uris(self, uris, urisDeprecated):
         """ Add the URIs (which should be a list) """
+        has_resource_block_uris = False
         uri_block = self.format_head_three(_('URIs'), self.level)
         for uri in sorted(uris, key=str.lower):
-            uri_block += "\n" + self.format_uri(uri) + "<br>"
+            if 'ResourceBlocks' in uri:   # trim out resource block-related URIs
+                has_resource_block_uris = True
+                continue
+            if uri in urisDeprecated:
+                uri_block += "\n" + self.format_uri(uri) + _(" (deprecated)") +"<br>"
+            else:
+                uri_block += "\n" + self.format_uri(uri) + "<br>"
+
+        if has_resource_block_uris:  # if URIs were trimmed, add a note
+            uri_block += "\n" + _("* Note: Resource block-related URIs have been omitted from this list") + "<br>"
+            
         self.this_section['uris'] = uri_block + "\n"
 
 

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -949,7 +949,7 @@ class MarkdownGenerator(DocFormatter):
         has_resource_block_uris = False
         uri_block = self.format_head_three(_('URIs'), self.level)
         for uri in sorted(uris, key=str.lower):
-            if '{ResourceBlockId}/' in uri:   # trim out resource block-related URIs
+            if (not self.config.get('normative')) and ('{ResourceBlockId}/' in uri):   # trim out resource block-related URIs
                 has_resource_block_uris = True
                 continue
             if uri in urisDeprecated:

--- a/doc-generator/doc_formatter/property_index_generator.py
+++ b/doc-generator/doc_formatter/property_index_generator.py
@@ -541,7 +541,7 @@ table.properties{
         """ This is for the schema description. We don't actually use this. """
         pass
 
-    def add_uris(self, uris):
+    def add_uris(self, uris, urisDeprecated):
         """ omit URIs """
         pass
 

--- a/doc-generator/doc_generator.py
+++ b/doc-generator/doc_generator.py
@@ -1223,6 +1223,7 @@ class DocGenerator:
             'excluded_properties': [],
             'excluded_by_match': [],
             'excluded_schemas': [],
+            'excluded_schema_uris': [],
             'excluded_schemas_by_match': [],
             'excluded_pattern_props': [],
             'description_overrides': {},
@@ -1301,7 +1302,7 @@ class DocGenerator:
                 'actions_in_property_table', 'html_title',
                 'uri_to_local', 'local_to_uri', 'profile_uri_to_local', 'registry_uri_to_local',
                 'combine_multiple_refs', 'omit_version_in_headers',
-                'supplement_md_dir',
+                'supplement_md_dir', 'excluded_schema_uris',
                 'table_formats',
                 'remove_blanks',
                 'description_overrides' # this is for property_index mode only

--- a/doc-generator/doc_generator.py
+++ b/doc-generator/doc_generator.py
@@ -407,6 +407,7 @@ class DocGenerator:
                     warnings.warn('Unable to process files for %(uri)s' % {'uri': normalized_uri})
                 continue
             data['uris'] = schema_data[normalized_uri].get('_uris', [])
+            data['urisDeprecated'] = schema_data[normalized_uri].get('_urisDeprecated', [])
 
             if normalized_uri.endswith('Collection.json'):
                 [preamble, collection_name] = normalized_uri.rsplit('/', 1)
@@ -605,6 +606,10 @@ class DocGenerator:
             if 'uris' in data:
                 # Stash these in the unversioned schema_data.
                 all_schemas[normalized_uri]['_uris'] = data['uris']
+            
+            if 'urisDeprecated' in data:
+                # Stash the deprecated URIs as well
+                all_schemas[normalized_uri]['_urisDeprecated'] = data['urisDeprecated']
 
             if len(ref_files):
                 # Add the _is_versioned_schema and  is_collection_of hints to each ref object

--- a/doc-generator/sample_inputs/standard_html/config.json
+++ b/doc-generator/sample_inputs/standard_html/config.json
@@ -31,6 +31,9 @@
         "idRef",
         "Oem"
     ],
+    "excluded_schema_uris": [
+        "{ResourceBlockId}/"
+	],
     "excluded_pattern_properties": [
         "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$"
     ],


### PR DESCRIPTION
Also, trim `ResourceBlock` related URIs from the URI list for brevity, but add a note to the URI list to explain that.