### PR TITLE
Fixes and partial fixes for Profile and Subset output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.pyc
 redfish-repo-test/node_modules/
 redfish-repo-test/package-lock.json
+.vs/
+doc-generator/.idea/

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -1186,6 +1186,10 @@ class DocFormatter:
             warnings.warn("filter_props_by_subset was called with no subset data")
             return prop_names
 
+        # Handle special case for @odata.id for link properties, always include it
+        if prop_names == ['@odata.id']:
+            return(prop_names)
+
         # Actions have Parameters, properties have Properties.
         subsection = 'Properties'
         if 'Parameters' in subset:
@@ -1211,10 +1215,6 @@ class DocFormatter:
         if profile is None:
             warnings.warn("filter_props_by_profile was called with no profile data")
             return prop_names
-
-        # Handle special case for @odata.id for link properties, always include it
-        if prop_names == ['@odata.id']:
-            return(prop_names)
 
         if profile.get('PropertyRequirements') is None and not is_action:
             # if a resource is specified with no PropertyRequirements, include them all...
@@ -1999,7 +1999,7 @@ class DocFormatter:
                     profile = self.get_prop_profile(schema_ref, prop_path, profile_section)
 
                 if profile:
-                    prop_names = self.filter_props_by_profile(prop_names, profile, parent_requires, is_action)
+                    prop_names = self.filter_props_by_profile(prop_names, profile, [], is_action)
                 prop_names.sort(key=str.lower)
 
             elif self.config.get('subset_mode'):

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -1212,6 +1212,10 @@ class DocFormatter:
             warnings.warn("filter_props_by_profile was called with no profile data")
             return prop_names
 
+        # Handle special case for @odata.id for link properties, always include it
+        if prop_names == ['@odata.id']:
+            return(prop_names)
+
         if profile.get('PropertyRequirements') is None and not is_action:
             # if a resource is specified with no PropertyRequirements, include them all...
             # but do omit "Actions" if there are no ActionRequirements (profile mode).

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -2309,7 +2309,7 @@ class DocFormatter:
         Returns None if no data is present ({} is a valid data-present result)."""
 
         prop_profile = None
-        if prop_path[0] == 'Actions':
+        if len(prop_path) and prop_path[0] == 'Actions':
             section = 'ActionRequirements'
 
         if self.config.get('profile_resources'):

--- a/doc-generator/doc_generator.py
+++ b/doc-generator/doc_generator.py
@@ -705,7 +705,7 @@ class DocGenerator:
                 min_version = schema_profile.get('MinVersion')
                 if min_version:
                     if version:
-                        property_data['name_and_version'] += ' ' + ('v%(minversion)s (current release: v%(version)s'
+                        property_data['name_and_version'] += ' ' + ('v%(minversion)s (current release: v%(version)s)'
                             % {'minversion': min_version, 'version': version})
                     else:
                         # this is unlikely
@@ -1392,7 +1392,7 @@ class DocGenerator:
             profile_doc = os.path.normpath(combined_args['profile_doc'])
             errors = []
             try:
-                profile_doc_local = os.path.normpath(os.path.join(config_data['config_dir'], subset_doc))
+                profile_doc_local = os.path.normpath(os.path.join(config_data['config_dir'], profile_doc))
                 profile = open(profile_doc_local, 'r', encoding="utf8")
                 profile.close()
                 config['profile_doc'] = profile_doc_local


### PR DESCRIPTION
In Subset and Profile modes, handling of "link" properties (which are objects with a single `@odata.id` property) is incorrect and difficult to unravel fixes.  When combined with the "terse" profile mode, link properties with simple mandatory requirements - and notated simply in the profile document as an empty object, as in:
```
   "EnvironmentMetrics": {}
```
are expanded to include every property in the linked schema (the profile default being "if not specified, everything inside is required").  This may need to be further clarified in the profile specification.  

The fixes here will at least give an escape for subset mode to show the single property within those link property objects.  And for profiles, the requirements of the "parent" schema were being incorrectly applied to the child objects.  This removed the full expansion issue (which makes the resulting output very wrong), and the further workaround is for profile authors to include `@odata.id` requirements in their profile document, such as applying to the example above:

```
   "EnvironmentMetrics" { 
      "PropertyRequirements": {
         "@odata.id": {
            "ReadRequirement": "Mandatory"
          }
      }
   }
```
       
And a number of minor issues corrected:
- Copy/paste error between subset / profile mode causes a crash due to "subset" document being None
- Missing ")" on section title
- Added check for array length before access