### PR TITLE
Added explicit inclusion of the YAML loader argument for pyyaml 6.0

### DIFF
--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -172,7 +172,7 @@ class JSONToYAML:
         """
         try:
             with open( filename ) as yaml_file:
-                yaml_data = yaml.load( yaml_file )
+                yaml_data = yaml.load( yaml_file, Loader=yaml.Loader )
         except:
             print( "ERROR: Could not open {}".format( filename ) )
             return


### PR DESCRIPTION
If a user has pyyaml 6.0 or higher, they will hit an exception when trying to extend an existing openapi.yaml file. Pyyaml made a breaking change that requires consumers to specify the type of YAML loader. This argument is supported in older versions of pyyaml, so this won't break existing users for us.