### PR TITLE
Skip non-JSON URIs when loading from a base OpenAPI file

### DIFF
--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -180,6 +180,10 @@ class JSONToYAML:
         # Go through each URI
         for uri in yaml_data["paths"]:
             if "get" in yaml_data["paths"][uri]:
+                if "application/json" not in yaml_data["paths"][uri]["get"]["responses"]["200"]["content"]:
+                    # Skip non-JSON URIs
+                    # So far this is limited to /redfish/v1/$metadata, which will be added back in at the end of the conversion
+                    continue
                 # This is a resource; copy data to the URI cache
                 self.uri_cache[uri] = {}
                 self.uri_cache[uri]["reference"] = yaml_data["paths"][uri]["get"]["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]

--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -179,11 +179,12 @@ class JSONToYAML:
 
         # Go through each URI
         for uri in yaml_data["paths"]:
+            # Don't add $metadata or odata; these are not formatted like other responses
+            # These will be added back automatically later in the tool
+            if uri == "/redfish/v1/$metadata" or uri == "/redfish/v1/odata":
+                continue
+
             if "get" in yaml_data["paths"][uri]:
-                if "application/json" not in yaml_data["paths"][uri]["get"]["responses"]["200"]["content"]:
-                    # Skip non-JSON URIs
-                    # So far this is limited to /redfish/v1/$metadata, which will be added back in at the end of the conversion
-                    continue
                 # This is a resource; copy data to the URI cache
                 self.uri_cache[uri] = {}
                 self.uri_cache[uri]["reference"] = yaml_data["paths"][uri]["get"]["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]


### PR DESCRIPTION
When loading from a base OpenAPI file, an exception is raised when processing the /redfish/v1/$metadata entry due to the lack of an "application/json" entry under "content". The change here just skips over non-JSON URIs with the expectation that they will be added back later. If we ever grow beyond just /redfish/v1/$metadata as the only non-JSON thing to capture in openapi.yaml, we might need to revisit this.