### PR TITLE
Added conversion of Edm.Double to number

### DIFF
--- a/csdl-to-json-convertor/csdl-to-json.py
+++ b/csdl-to-json-convertor/csdl-to-json.py
@@ -1222,7 +1222,7 @@ class CSDLToJSON:
                 json_type = [ "integer", "null" ]
             else:
                 json_type = "integer"
-        elif type == "Edm.Decimal":
+        elif ( type == "Edm.Decimal" ) or ( type == "Edm.Double" ):
             if is_nullable:
                 json_type = [ "number", "null" ]
             else:


### PR DESCRIPTION
Gap was found when reviewing the primitive CSDL types listed in the Redfish Spec; we allow for `Edm.Double`, but do not have it in the conversion process.