### PR TITLE
replace deprecated name "spmf" with "redfish"

### DIFF
--- a/doc-generator/README.md
+++ b/doc-generator/README.md
@@ -114,7 +114,7 @@ optional arguments:
 
 Example:
    doc_generator.py --format=html
-   doc_generator.py --format=html --out=/path/to/output/index.html /path/to/spmf/json-files
+   doc_generator.py --format=html --out=/path/to/output/index.html /path/to/redfish/json-files
 ```
 
 Refer to [Property Index Mode](README_Property_Index.md) for documentation on Property Index mode.


### PR DESCRIPTION
@mraineri , I was reading up about the documentation generator, and I saw the old name "spmf". This commit updates "spmf" to "redfish" in the readme, if you think it's worth the change.