### PR TITLE
Reformatted  usage to use oneOf to ensure it doesn't collide with the nullable usage

### DIFF
--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -437,11 +437,10 @@ class JSONToYAML:
         if "anyOf" in json_data and len( json_data["anyOf"] ) > 0:
             # Two patterns we follow for "anyOf" usage:
             # 1) Arrays to show an item can be a particular definition or null
-            # In this case, we need to use the OpenAPI "nullable" term
+            # In this case, we need to use the OpenAPI "oneOf" term to point to the reference and null
             if json_data["anyOf"][-1] == { "type": "null" }:
-                json_data["$ref"] = json_data["anyOf"][0]["$ref"]
+                json_data["oneOf"] = [ { "$ref": json_data["anyOf"][0]["$ref"] }, { "enum": [ "null" ] } ]
                 json_data.pop( "anyOf" )
-                json_data["nullable"] = True
             # 2) Abstract base definitions that point to every versioned definition
             # Keeping this causes significant client code bloat, so just use the latest version
             else:

--- a/json-to-openapi-converter/json-to-yaml.py
+++ b/json-to-openapi-converter/json-to-yaml.py
@@ -571,8 +571,8 @@ class JSONToYAML:
                     "type": "object",
                     "properties": {
                         "code": {
-                            "description": "A string indicating a specific MessageId from a message registry.",
-                            "x-longDescription": "This property shall contain a string indicating a specific MessageId from a message registry.",
+                            "description": "A string indicating a specific `MessageId` from a message registry.",
+                            "x-longDescription": "This property shall contain a string indicating a specific `MessageId` from a message registry.",
                             "readOnly": True,
                             "type": "string"
                         },


### PR DESCRIPTION
Fix #464 

@commonism FYI here are the before and after for some properties:

Before...

```
        Description:
          $ref: http://redfish.dmtf.org/schemas/v1/Resource.yaml#/components/schemas/Resource_Description
          nullable: true
          readOnly: true

        EnvironmentalClass:
          $ref: '#/components/schemas/Chassis_v1_25_0_EnvironmentalClass'
          description: The ASHRAE Environmental Class for this chassis.
          nullable: true
          readOnly: false
          x-longDescription: This property shall contain the ASHRAE Environmental
            Class for this chassis, as defined by ASHRAE Thermal Guidelines for Data
            Processing Environments.  These classes define respective environmental
            limits that include temperature, relative humidity, dew point, and maximum
            allowable elevation.
          x-versionAdded: v1_9_0

        IPv4StaticAddresses:
          description: The IPv4 static addresses assigned to this interface.  See
            IPv4Addresses for the addresses in use by this interface.
          items:
            $ref: http://redfish.dmtf.org/schemas/v1/IPAddresses.yaml#/components/schemas/IPAddresses_IPv4Address
            nullable: true
          type: array
          x-longDescription: This property shall contain an array of objects that
            represent all IPv4 static addresses assigned to, but not necessarily in
            use by, this interface.  The IPv4Addresses property shall also list the
            addresses that this interface uses.
          x-versionAdded: v1_4_0
```

After...

```
        Description:
          oneOf:
          - $ref: http://redfish.dmtf.org/schemas/v1/Resource.yaml#/components/schemas/Resource_Description
          - enum:
            - 'null'
          readOnly: true

        EnvironmentalClass:
          description: The ASHRAE Environmental Class for this chassis.
          oneOf:
          - $ref: '#/components/schemas/Chassis_v1_25_0_EnvironmentalClass'
          - enum:
            - 'null'
          readOnly: false
          x-longDescription: This property shall contain the ASHRAE Environmental
            Class for this chassis, as defined by ASHRAE Thermal Guidelines for Data
            Processing Environments.  These classes define respective environmental
            limits that include temperature, relative humidity, dew point, and maximum
            allowable elevation.
          x-versionAdded: v1_9_0

        IPv4StaticAddresses:
          description: The IPv4 static addresses assigned to this interface.  See
            IPv4Addresses for the addresses in use by this interface.
          items:
            oneOf:
            - $ref: http://redfish.dmtf.org/schemas/v1/IPAddresses.yaml#/components/schemas/IPAddresses_IPv4Address
            - enum:
              - 'null'
          type: array
          x-longDescription: This property shall contain an array of objects that
            represent all IPv4 static addresses assigned to, but not necessarily in
            use by, this interface.  The IPv4Addresses property shall also list the
            addresses that this interface uses.
          x-versionAdded: v1_4_0
```