### PR TITLE
Removed workaround for stub excerpts where 'Name' in Resource used to be tagged as an excerpt

### DIFF
--- a/csdl-to-json-convertor/csdl-to-json.py
+++ b/csdl-to-json-convertor/csdl-to-json.py
@@ -324,12 +324,7 @@ class CSDLToJSON:
                          excerpt_list.append(e)
             if "excerptCopyOnly" in prop:
                 count = count + 1
-        if count == 1:
-            # Exactly 1 excerpt; this happens if only the Name property is an excerpt
-            # Do not make an excerpt definition for this
-            base_def["properties"]["Name"].pop( "excerpt" )
-            return
-        elif count < 1:
+        if count == 0:
             # No excerpts at all
             return
 


### PR DESCRIPTION
Resource 1.8.3 removed "Name" as an excerpt property, so this workaround isn't needed anymore.