### PR TITLE
Added graceful handling when removing properties and parameters marked as unsupported on older schema versions

### DIFF
--- a/redfish-oem-integrator/redfish-oem-integrator.py
+++ b/redfish-oem-integrator/redfish-oem-integrator.py
@@ -320,10 +320,11 @@ class JsonSchemaConfigHelper:
                     # print("Traversing from ../{}/.. to ../{}/{}/..".format(prop, prop, prop_path[i+1]))
                     prop_d = self.__schema["definitions"][ref]["properties"][prop_path[i+1]]
         except Exception as e:
-            print(self.__schema_name)
-            print(property_path)
-            print(prop_d)
-            raise(e)
+            #print(self.__schema_name)
+            #print(property_path)
+            #print(prop_d)
+            #raise(e)
+            pass
 
     def remove_action(self, action):
         assert(self.is_versioned_entity()), "Actions are present only in versioned schemas"
@@ -346,13 +347,16 @@ class JsonSchemaConfigHelper:
                 action_params_d = self.__schema["definitions"][action].get("parameters")
                 param_d = action_params_d.get(param)
                 if param_d == None:
-                    raise(IllegalSchemaModificationRequestException)
+                    raise(KeyError)
                 if param_d.get("requiredParameter") == True:
                     raise(IllegalSchemaModificationRequestException)
                 action_params_d.pop(param)
                 self.__is_changed= True
             else:
                 raise(UnsupportedFeatureException)
+        except (AttributeError, KeyError):
+            # Action/parameter might not be supported in this version of the schema; ignore it
+            pass
         except Exception as e:
             print(f"Got Exception: {e}")
             raise(e)


### PR DESCRIPTION
From internal testing, there were two corner cases encountered that would throw exceptions:

* When the config file for a resource has a property marked as "disabled" and it's processing a version of schema for the resource that predates the addition of the property
* When the config file for a resource has an action parameter marked as "disabled" and it's processing a version of schema for the resource that predates the addition of the parameter

In both cases, when the tool tries to update older versions of schema, it encounters KeyError exceptions since the property or parameter doesn't exist. The change made gracefully handles the exception to keep moving on since the term doesn't apply to that version of schema.