### PR TITLE
Treat new line as row in markdown table generation

### DIFF
--- a/doc-generator/format_utils/format_utils.py
+++ b/doc-generator/format_utils/format_utils.py
@@ -92,7 +92,7 @@ class FormatUtils():
     def make_table(self, rows, header_rows=None, css_class=None, last_column_wide=False):
 
         # Get the number of cells from the first row.
-        firstrow = rows[0]
+        firstrow = rows[0].split('\n')[0]
         numcells = firstrow.count(' | ') + 1
         if not header_rows:
             header_rows = [ self.make_header_row(['   ' for x in range(0, numcells)]) ]


### PR DESCRIPTION
Split via an extraneous linebreak '\n' character when generating tables via make_table in markdown, as this causes numcells to include subsequent rows.

This may be more adequately fixed at the source in format_property_row, as it only generates a single string as a row with '\n' as a delimiter, line 314

Fix #468

edit:  new output

![image](https://github.com/user-attachments/assets/fc442db9-4595-44a4-a8ab-9d773f00dfcc)

vs original 

![image](https://github.com/user-attachments/assets/4f486d88-e95c-4dc4-b3e1-3cf962896b05)
