### PR TITLE
Fixed regex pattern used for annotations in OEM extensions

### DIFF
--- a/redfish-oem-integrator/redfish-oem-integrator.py
+++ b/redfish-oem-integrator/redfish-oem-integrator.py
@@ -182,7 +182,7 @@ class JsonSchemaConfigHelper:
             "description": "An OEM extension to the {} resource.".format(self.get_name()),
             "longDescription": "This object represents the OEM properties of the {} resource. The resource values shall comply with the Redfish Specification-described requirements.".format(self.get_name()),
             "patternProperties": {
-                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                     "description": "This property shall specify a valid odata or Redfish property.",
                     "type": [
                         "array",
@@ -1245,7 +1245,7 @@ class DMTFOemIntegrator:
                                         "description": "The OEM extension to the %s resource." %(schema),
                                         "longDescription": "This object represents the OEM properties. The resource values shall comply with the Redfish Specification-described requirements.",
                                         "patternProperties": {
-                                            "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                                            "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                                                 "description": "This property shall specify a valid odata or Redfish property.",
                                                 "type": [
                                                     "array",
@@ -1292,7 +1292,7 @@ class DMTFOemIntegrator:
                                         "description": "The OEM Links extension to the %s resource." %(schema),
                                         "longDescription": "This object represents the OEM properties. The resource values shall comply with the Redfish Specification-described requirements.",
                                         "patternProperties": {
-                                            "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                                            "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
                                                 "description": "This property shall specify a valid odata or Redfish property.",
                                                 "type": [
                                                     "array",


### PR DESCRIPTION
Someone internal showed me the output of an inserted OEM extension and the resultant pattern was not aligned with the annotations pattern we use elsewhere.

This was showing up in the final yaml output at the end of the toolchain:

```
      x-patternProperties:
        ^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$:
          description: This property shall specify a valid odata or Redfish property.
```

The extra slash after Message results in it searching for a slash followed by any character, when the intent is to escape the . character to indicate we're searching for a . character.

The intended output should be:

```
      x-patternProperties:
        ^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\.[a-zA-Z_][a-zA-Z0-9_]*$:
          description: This property shall specify a valid odata or Redfish property.
```